### PR TITLE
Add transaction types

### DIFF
--- a/transaction/action.go
+++ b/transaction/action.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package transaction
+
+// Action represents an action secured by a multi-signature wrapper.
+type Action interface {
+	ID() []byte
+}

--- a/transaction/creation.go
+++ b/transaction/creation.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package transaction
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// Creation creates a new account.
+type Creation struct {
+	Origin      []byte   // account issuing the creation of a new account
+	Target      []byte   // target account to be created
+	Required    uint64   // number of signatories required for a valid signature
+	Signatories [][]byte // public keys of the valid account signatories
+}
+
+// ID returns the ID of the cration transaction.
+func (c Creation) ID() []byte {
+	h, _ := blake2b.New256(nil)
+	h.Write(c.Origin)
+	h.Write(c.Target)
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, c.Required)
+	h.Write(buf)
+	for _, signatory := range c.Signatories {
+		h.Write(signatory)
+	}
+	return h.Sum(nil)
+}

--- a/transaction/fee.go
+++ b/transaction/fee.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package transaction
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// Fee represents a signed fee transaction.
+type Fee struct {
+	Origin []byte // account issuing the fee transaction
+	Target []byte // account or action ID that the fee is meant for
+	Amount uint64 // amount made available in fees
+	Nonce  uint64 // nonce to doubling fee on same target
+}
+
+// ID returns the ID of the fee transaction.
+func (f Fee) ID() []byte {
+	h, _ := blake2b.New256(nil)
+	h.Write(f.Origin)
+	h.Write(f.Target)
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, f.Amount)
+	h.Write(buf)
+	binary.LittleEndian.PutUint64(buf, f.Nonce)
+	h.Write(buf)
+	return h.Sum(nil)
+}

--- a/transaction/multisig.go
+++ b/transaction/multisig.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package transaction
+
+// Signature represents a multisig wrapper for transactions.
+type Signature struct {
+	Action Action   // the underlying action to be executed
+	Sigs1  [][]byte // the signatures that should correspond to the origin of the action
+	Fee    Fee      // the attached fee transaction
+	Sigs2  [][]byte // the signatures that should correspond to the origin of the fees
+}

--- a/transaction/signature.go
+++ b/transaction/signature.go
@@ -19,8 +19,8 @@ package transaction
 
 // Signature represents a multisig wrapper for transactions.
 type Signature struct {
-	Action Action   // the underlying action to be executed
-	Sigs1  [][]byte // the signatures that should correspond to the origin of the action
-	Fee    Fee      // the attached fee transaction
-	Sigs2  [][]byte // the signatures that should correspond to the origin of the fees
+	Action     Action   // the underlying action to be executed
+	ActionSigs [][]byte // the signatures that should correspond to the origin of the action
+	Fee        Fee      // the attached fee transaction
+	FeeSigs    [][]byte // the signatures that should correspond to the origin of the fees
 }

--- a/transaction/transfer.go
+++ b/transaction/transfer.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package transaction
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// Transfer represents a value transfer transaction.
+type Transfer struct {
+	From   []byte // origin account of the transfer
+	To     []byte // target account of the transfer
+	Amount uint64 // amount to be transfered
+	Nonce  uint64 // nonce to make sure we can issue same transfer again
+}
+
+// ID returns the ID of the transfer.
+func (t Transfer) ID() []byte {
+	h, _ := blake2b.New256(nil)
+	h.Write(t.From)
+	h.Write(t.To)
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, t.Amount)
+	h.Write(buf)
+	binary.LittleEndian.PutUint64(buf, t.Nonce)
+	h.Write(buf)
+	return h.Sum(nil)
+}


### PR DESCRIPTION
This PR adds the types for transactions:

- action is an interface for any kind of action that we need to pay for on the network
- creation is for the creation of a new account with the corresponding signatories
- transfer is for the transfer of tokens from one account to another
- fee is a transaction from an account to pay for actions
- signature is a wrapper around actions that includes the signatures necessary for both the action and the fee

It is required to continue work on the miner in a meaningful way.