### PR TITLE
changed dependency injections approach

### DIFF
--- a/network/book.go
+++ b/network/book.go
@@ -46,8 +46,8 @@ func NewBook() *Book {
 	}
 }
 
-// Add will add an address to the list of available peer addresses, unless it is blacklisted.
-func (b *Book) Add(address string) {
+// Found will add an address to the list of available peer addresses, unless it is blacklisted.
+func (b *Book) Found(address string) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 	_, ok := b.blacklist[address]

--- a/network/listener.go
+++ b/network/listener.go
@@ -25,12 +25,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// Listener contains the manager dependencies we need to handle listening.
-type Listener interface {
+type listenerActions interface {
 	StartAcceptor(conn net.Conn)
 }
 
-func handleListening(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, mgr Listener, stop <-chan struct{}) {
+func handleListening(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, actions listenerActions, stop <-chan struct{}) {
 	defer wg.Done()
 
 	// extract the config parameters we are interested in
@@ -81,7 +80,7 @@ Loop:
 
 		// we should handle onboarding on a new goroutine to avoid blocking
 		// on listening, and as well so we can release slots with defer
-		mgr.StartAcceptor(conn)
+		actions.StartAcceptor(conn)
 	}
 
 	// ordered to quit, we close the listener down


### PR DESCRIPTION
This PR clearly separates the dependencies injected into handlers into three categories:
- infos: anything that is read-only on the state, to get some needed information
- actions: anything that actively modifies the state (mostly with possibility of error)
- events: anything that passively changes the state (might have impact in the future, no error possible)

This could allow us to refactor the manager clearly into execution logic and state, which can be injected separately into the handlers then.