### PR TITLE
Implement naive miner

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   revision = "18fdff33d8fa6779a6eb859c3fbe0d330b340da2"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/dgraph-io/badger"
   packages = [".","options","protos","skl","table","y"]
   revision = "69611218c7078be6de16f4ea13fb256e701b6b73"
@@ -50,6 +56,12 @@
   version = "v0.8.0"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/rs/zerolog"
   packages = [".","internal/json"]
   revision = "3ac71fc58dbd43122668a912b755b0979ba9ce1f"
@@ -60,6 +72,18 @@
   packages = ["."]
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
+  version = "v0.1"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = ["assert","mock","require","suite"]
+  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -100,6 +124,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "862a34ab6456ea1c60c7fb0b415953f44c8248ca59b3354e8e4d8b1507f3dcf5"
+  inputs-digest = "5b31cd3e0f9c1594fbd28af79088b88dea50e51bc0506d1103235eb56af4936f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package miner
+
+import "github.com/alvalor/alvalor-go/types"
+
+// Miner defines the interface we want to use for mining.
+type Miner interface {
+	Start()
+	AddTx(types.Transaction)
+	Stop()
+}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -21,7 +21,8 @@ import "github.com/alvalor/alvalor-go/types"
 
 // Miner defines the interface we want to use for mining.
 type Miner interface {
-	Start()
-	AddTx(types.Transaction)
+	Start() <-chan types.Header
+	Parent(types.Header)
+	Delta([]byte)
 	Stop()
 }

--- a/miner/naive.go
+++ b/miner/naive.go
@@ -31,6 +31,7 @@ type Naive struct {
 	data   []byte
 	parent chan types.Header
 	delta  chan []byte
+	target chan []byte
 	stop   chan struct{}
 	out    chan types.Header
 }
@@ -40,6 +41,8 @@ func NewNaive(miner []byte, parent types.Header, delta []byte, target []byte) *N
 	nv := &Naive{
 		data:   make([]byte, 176),
 		parent: make(chan types.Header, 1),
+		delta:  make(chan []byte),
+		target: make(chan []byte),
 		stop:   make(chan struct{}),
 	}
 	copy(nv.data[0:32], parent.Hash())
@@ -71,6 +74,11 @@ func (nv *Naive) Parent(parent types.Header) {
 // Delta will update the block we try to mine with a new transaction root hash.
 func (nv *Naive) Delta(delta []byte) {
 	nv.delta <- delta
+}
+
+// Target will change the target difficulty of the block hash.
+func (nv *Naive) Target(target []byte) {
+	nv.target <- target
 }
 
 // mine is the mining loop.

--- a/miner/naive.go
+++ b/miner/naive.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package miner
+
+import (
+	"bytes"
+	"encoding/binary"
+	"time"
+
+	"github.com/alvalor/alvalor-go/types"
+	"golang.org/x/crypto/blake2b"
+)
+
+// Naive represents a naive miner which is not efficient but easy to understand.
+type Naive struct {
+	header types.Header
+	parent chan []byte
+	state  chan []byte
+	delta  chan []byte
+	target chan []byte
+	out    chan types.Header
+	stop   chan struct{}
+}
+
+// NewNaive creates a new naive miner initialized with the given parameters.
+func NewNaive(parent []byte, state []byte, delta []byte, miner []byte, target []byte) *Naive {
+	header := types.Header{
+		Parent: parent,
+		State:  state,
+		Delta:  delta,
+		Miner:  miner,
+		Target: target,
+		Nonce:  0,
+		Time:   time.Now(),
+	}
+	return &Naive{
+		header: header,
+		parent: make(chan []byte, 1),
+		state:  make(chan []byte, 1),
+		delta:  make(chan []byte, 1),
+		target: make(chan []byte, 1),
+		stop:   make(chan struct{}),
+	}
+}
+
+// Start will start the mining process.
+func (nv *Naive) Start() <-chan types.Header {
+	nv.out = make(chan types.Header)
+	go nv.mine()
+	return nv.out
+}
+
+// Stop will stop the mining process.
+func (nv *Naive) Stop() {
+	close(nv.out)
+	close(nv.stop)
+}
+
+// Parent will update the block we try to mine with a new parent hash.
+func (nv *Naive) Parent(parent []byte) {
+	nv.parent <- parent
+}
+
+// Delta will update the block we try to mine with a new transaction root hash.
+func (nv *Naive) Delta(delta []byte) {
+	nv.delta <- delta
+}
+
+// Target will update the target difficulty we are trying to mine for.
+func (nv *Naive) Target(target []byte) {
+	nv.target <- target
+}
+
+// mine is the mining loop.
+func (nv *Naive) mine() {
+Loop:
+	for {
+		select {
+		case <-nv.stop:
+			break Loop
+		case parent := <-nv.parent:
+			nv.header.Parent = parent
+			nv.header.Nonce = 0
+			continue Loop
+		case state := <-nv.state:
+			nv.header.State = state
+			nv.header.Nonce = 0
+			continue Loop
+		case delta := <-nv.delta:
+			nv.header.Delta = delta
+			nv.header.Nonce = 0
+		case target := <-nv.target:
+			nv.header.Target = target
+			nv.header.Nonce = 0
+		default:
+			// go on
+		}
+		nv.header.Time = time.Now()
+		h, _ := blake2b.New256(nil)
+		_, _ = h.Write(nv.header.Parent)
+		_, _ = h.Write(nv.header.State)
+		_, _ = h.Write(nv.header.Delta)
+		_, _ = h.Write(nv.header.Miner)
+		_, _ = h.Write(nv.header.Target)
+		ts := make([]byte, 8)
+		binary.LittleEndian.PutUint64(ts, uint64(nv.header.Time.Unix()))
+		_, _ = h.Write(ts)
+		hash := h.Sum(nil)
+		if bytes.Compare(hash, nv.header.Target) < 0 {
+			nv.out <- nv.header
+		}
+		nv.header.Nonce++
+	}
+}

--- a/miner/naive.go
+++ b/miner/naive.go
@@ -59,8 +59,8 @@ func (nv *Naive) Start() <-chan types.Header {
 
 // Stop will stop the mining process.
 func (nv *Naive) Stop() {
-	close(nv.out)
 	close(nv.stop)
+	<-nv.out
 }
 
 // Parent will update the block we try to mine with a new parent hash.
@@ -121,4 +121,5 @@ Loop:
 		}
 		nonce++
 	}
+	close(nv.out)
 }

--- a/types/block.go
+++ b/types/block.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+// Block represents a proof of work block on the Alvalor base layer.
+type Block struct {
+	Header
+	Transactions []Transaction
+}

--- a/types/header.go
+++ b/types/header.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"time"
+)
+
+// Header represents the header data of a block that will be hashed.
+type Header struct {
+	Parent []byte
+	State  []byte
+	Delta  []byte
+	Miner  []byte
+	Target []byte
+	Nonce  uint64
+	Time   time.Time
+}

--- a/types/header.go
+++ b/types/header.go
@@ -18,7 +18,10 @@
 package types
 
 import (
+	"encoding/binary"
 	"time"
+
+	"golang.org/x/crypto/blake2b"
 )
 
 // Header represents the header data of a block that will be hashed.
@@ -28,6 +31,21 @@ type Header struct {
 	Delta  []byte
 	Miner  []byte
 	Target []byte
-	Nonce  uint64
 	Time   time.Time
+	Nonce  uint64
+}
+
+// Hash returns the hash (ID) of the block with the given header.
+func (hdr Header) Hash() []byte {
+	h, _ := blake2b.New256(nil)
+	_, _ = h.Write(hdr.Parent)
+	_, _ = h.Write(hdr.State)
+	_, _ = h.Write(hdr.Delta)
+	_, _ = h.Write(hdr.Miner)
+	_, _ = h.Write(hdr.Target)
+	data := make([]byte, 16)
+	binary.LittleEndian.PutUint64(data[:8], uint64(hdr.Time.Unix()))
+	binary.LittleEndian.PutUint64(data[8:], hdr.Nonce)
+	_, _ = h.Write(data)
+	return h.Sum(nil)
 }


### PR DESCRIPTION
This PR contains code for a simple implementation of a miner in Go.

The goal is to write simple code that is easy to understand and does not sacrifice readability for increased performance.

The goal is not to write optimized code with assembly and fancy tricks to squeeze out every inch of performance.

Currently, the code does not have logic to adjust the difficulty. The plan is to have 10 second blocks and a moving average for difficulty over the last 360 blocks (1 hour).

It also does currently no automatically create a new hash for the root of the transaction trie when a block has been found (either locally or remotely). The question is whether we should handle that internally or not. The bigger question in that respect is whether we should store a separate transaction trie for the miner or not.