### PR TITLE
Add sorts & filters tests

### DIFF
--- a/network/book_test.go
+++ b/network/book_test.go
@@ -166,7 +166,7 @@ func TestSample(t *testing.T) {
 	expected = []string{addr6, addr5, addr1, addr4, addr7, addr3, addr2}
 	assert.Equal(t, expected, actual, "By score sort returns wrong ordering")
 
-	actual = book.Sample(7, byHash(func(data []byte) []byte {
+	actual = book.Sample(7, byHashFunc(func(data []byte) []byte {
 		hasher := md5.New()
 		hasher.Write(data)
 		return hasher.Sum(nil)

--- a/network/filters.go
+++ b/network/filters.go
@@ -17,14 +17,14 @@
 
 package network
 
-func isActive(active bool) func(e *entry) bool {
-	return func(e *entry) bool {
-		return e.Active == active
-	}
-}
-
 func isAny() func(e *entry) bool {
 	return func(e *entry) bool {
 		return true
+	}
+}
+
+func isActive(active bool) func(e *entry) bool {
+	return func(e *entry) bool {
+		return e.Active == active
 	}
 }

--- a/network/filters_test.go
+++ b/network/filters_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAny(t *testing.T) {
+	vectors := map[string]struct {
+		filter   func(e *entry) bool
+		entry    *entry
+		expected bool
+	}{
+		"active entry": {
+			filter:   isAny(),
+			entry:    &entry{Active: true},
+			expected: true,
+		},
+		"inactive entry": {
+			filter:   isAny(),
+			entry:    &entry{Active: false},
+			expected: true,
+		},
+	}
+	for name, vector := range vectors {
+		actual := vector.filter(vector.entry)
+		assert.Equalf(t, vector.expected, actual, "Is any filter wrong result for %v", name)
+	}
+}
+
+func TestIsActive(t *testing.T) {
+	vectors := map[string]struct {
+		filter   func(e *entry) bool
+		entry    *entry
+		expected bool
+	}{
+		"active entry & active filter": {
+			filter:   isActive(true),
+			entry:    &entry{Active: true},
+			expected: true,
+		},
+		"inactive entry & active filter": {
+			filter:   isActive(true),
+			entry:    &entry{Active: false},
+			expected: false,
+		},
+		"active entry & inactive filter": {
+			filter:   isActive(false),
+			entry:    &entry{Active: true},
+			expected: false,
+		},
+		"inactive entry & inactive filter": {
+			filter:   isActive(false),
+			entry:    &entry{Active: false},
+			expected: true,
+		},
+	}
+	for name, vector := range vectors {
+		actual := vector.filter(vector.entry)
+		assert.Equalf(t, vector.expected, actual, "Is active filter wrong result for %v", name)
+	}
+}

--- a/network/sorts.go
+++ b/network/sorts.go
@@ -19,6 +19,7 @@ package network
 
 import (
 	"bytes"
+	"hash"
 	"math/rand"
 	"net"
 )
@@ -42,12 +43,16 @@ func byScoreFunc(score func(*entry) float64) func(*entry, *entry) bool {
 	}
 }
 
-func byHashFunc(hash func([]byte) []byte) func(*entry, *entry) bool {
+func byHashFunc(h hash.Hash) func(*entry, *entry) bool {
 	return func(e1 *entry, e2 *entry) bool {
 		ip1, _, _ := net.SplitHostPort(e1.Address)
+		h.Reset()
+		_, _ = h.Write([]byte(ip1))
+		h1 := h.Sum(nil)
 		ip2, _, _ := net.SplitHostPort(e2.Address)
-		h1 := hash([]byte(ip1))
-		h2 := hash([]byte(ip2))
+		h.Reset()
+		_, _ = h.Write([]byte(ip2))
+		h2 := h.Sum(nil)
 		return bytes.Compare(h1[:], h2[:]) < 0
 	}
 }

--- a/network/sorts.go
+++ b/network/sorts.go
@@ -23,9 +23,9 @@ import (
 	"net"
 )
 
-func byScoreFunc(score func(*entry) float64) func(*entry, *entry) bool {
-	return func(e1 *entry, e2 *entry) bool {
-		return score(e1) > score(e2)
+func byRandom() func(*entry, *entry) bool {
+	return func(*entry, *entry) bool {
+		return rand.Int()%2 == 0
 	}
 }
 
@@ -36,13 +36,13 @@ func byScore() func(*entry, *entry) bool {
 	})
 }
 
-func byRandom() func(*entry, *entry) bool {
-	return func(*entry, *entry) bool {
-		return rand.Int()%2 == 0
+func byScoreFunc(score func(*entry) float64) func(*entry, *entry) bool {
+	return func(e1 *entry, e2 *entry) bool {
+		return score(e1) > score(e2)
 	}
 }
 
-func byHash(hash func([]byte) []byte) func(*entry, *entry) bool {
+func byHashFunc(hash func([]byte) []byte) func(*entry, *entry) bool {
 	return func(e1 *entry, e2 *entry) bool {
 		ip1, _, _ := net.SplitHostPort(e1.Address)
 		ip2, _, _ := net.SplitHostPort(e2.Address)

--- a/network/sorts_test.go
+++ b/network/sorts_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestByRandom(t *testing.T) {
+	e := &entry{}
+	sort := byRandom()
+	mismatch := false
+	for i := 0; i < 100; i++ {
+		ok1 := sort(e, e)
+		ok2 := sort(e, e)
+		if ok1 != ok2 {
+			mismatch = true
+			break
+		}
+	}
+	assert.True(t, mismatch, "By random sort always returns same result")
+}
+
+func TestByScore(t *testing.T) {
+	sort := byScore()
+	vectors := map[string]struct {
+		entry1   *entry
+		entry2   *entry
+		expected bool
+	}{
+		"first score higher": {
+			entry1:   &entry{Success: 1, Failure: 0},
+			entry2:   &entry{Success: 0, Failure: 1},
+			expected: true,
+		},
+		"first score lower": {
+			entry1:   &entry{Success: 0, Failure: 1},
+			entry2:   &entry{Success: 1, Failure: 0},
+			expected: false,
+		},
+		"both equal score": {
+			entry1:   &entry{Success: 1, Failure: 1},
+			entry2:   &entry{Success: 1, Failure: 1},
+			expected: false,
+		},
+	}
+	for name, vector := range vectors {
+		actual := sort(vector.entry1, vector.entry2)
+		assert.Equalf(t, vector.expected, actual, "By score sort wrong result for %v", name)
+	}
+}
+
+func TestByScoreFunc(t *testing.T) {
+	value := map[bool]float64{true: 1, false: 0}
+	vectors := map[string]struct {
+		entry1   *entry
+		entry2   *entry
+		score    func(*entry) float64
+		expected bool
+	}{
+		"first active on active scoring": {
+			entry1:   &entry{Active: true},
+			entry2:   &entry{Active: false},
+			score:    func(e *entry) float64 { return value[e.Active] },
+			expected: true,
+		},
+		"second active on active scoring": {
+			entry1:   &entry{Active: false},
+			entry2:   &entry{Active: true},
+			score:    func(e *entry) float64 { return value[e.Active] },
+			expected: false,
+		},
+		"both active on active scoring": {
+			entry1:   &entry{Active: true},
+			entry2:   &entry{Active: true},
+			score:    func(e *entry) float64 { return value[e.Active] },
+			expected: false,
+		},
+		"first active on inactive scoring": {
+			entry1:   &entry{Active: true},
+			entry2:   &entry{Active: false},
+			score:    func(e *entry) float64 { return value[!e.Active] },
+			expected: false,
+		},
+		"second active on inactive scoring": {
+			entry1:   &entry{Active: false},
+			entry2:   &entry{Active: true},
+			score:    func(e *entry) float64 { return value[!e.Active] },
+			expected: true,
+		},
+		"both active on inactive scoring": {
+			entry1:   &entry{Active: true},
+			entry2:   &entry{Active: true},
+			score:    func(e *entry) float64 { return value[!e.Active] },
+			expected: false,
+		},
+	}
+	for name, vector := range vectors {
+		actual := byScoreFunc(vector.score)(vector.entry1, vector.entry2)
+		assert.Equalf(t, vector.expected, actual, "By score func sort wrong result for %v", name)
+	}
+}
+
+func TestByHashFunc(t *testing.T) {
+}


### PR DESCRIPTION
This PR adds data driven tests for the sort & filter functions. They are basically tested twice now, once separately and once as part of the sample function call, but it doesn't hurt.