### PR TITLE
Fix trie root hash computation

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -220,28 +220,26 @@ func (t *Trie) Hash() []byte {
 func (t *Trie) nodeHash(node node) []byte {
 	switch n := node.(type) {
 	case *fullNode:
-		t.h.Reset()
-		zero := t.h.Sum(nil)
-		t.h.Reset()
+		var hashes [][]byte
 		for _, child := range n.children {
-			if child == nil {
-				_, _ = t.h.Write(zero)
-				continue
-			}
-			_, _ = t.h.Write(t.nodeHash(child))
+			hashes = append(hashes, t.nodeHash(child))
+		}
+		t.h.Reset()
+		for _, hash := range hashes {
+			t.h.Write(hash)
 		}
 		return t.h.Sum(nil)
 	case *shortNode:
+		hash := t.nodeHash(n.child)
 		t.h.Reset()
 		t.h.Write(n.key)
-		t.h.Write(t.nodeHash(n.child))
+		t.h.Write(hash)
 		return t.h.Sum(nil)
 	case valueNode:
 		return []byte(n)
 	case nil:
 		t.h.Reset()
-		zero := t.h.Sum(nil)
-		return zero
+		return t.h.Sum(nil)
 	default:
 		panic("invalid node type")
 	}


### PR DESCRIPTION
Due to the new hasher interface and the recursive nature of the node hash function, it was possible that the hasher was reset in the recursive calls, leading to an invalid hash result. The new structure avoids any recursive calls between the reset, the writing of the data and the hash calculation.