### PR TITLE
Updated usage of uuid.NewV4() as it now returns multiple values

### DIFF
--- a/network/acceptor_test.go
+++ b/network/acceptor_test.go
@@ -44,9 +44,10 @@ func (suite *AcceptorSuite) SetupTest() {
 	suite.log = zerolog.New(ioutil.Discard)
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
+	v4, _ := uuid.NewV4()
 	suite.cfg = Config{
 		network: Odin,
-		nonce:   uuid.NewV4().Bytes(),
+		nonce:   v4.Bytes(),
 	}
 }
 
@@ -115,7 +116,8 @@ func (suite *AcceptorSuite) TestAcceptorNetworkMismatch() {
 
 	// arrange
 	address := "136.44.33.12:5523"
-	syn := append([]byte{1, 2, 3, 4}, uuid.NewV4().Bytes()...)
+	v4, _ := uuid.NewV4()
+	syn := append([]byte{1, 2, 3, 4}, v4.Bytes()...)
 	buf := make([]byte, len(syn))
 
 	addr := &AddrMock{}
@@ -187,7 +189,8 @@ func (suite *AcceptorSuite) TestAcceptorWriteFails() {
 
 	// arrange
 	address := "136.44.33.12:5523"
-	syn := append(suite.cfg.network, uuid.NewV4().Bytes()...)
+	v4, _ := uuid.NewV4()
+	syn := append(suite.cfg.network, v4.Bytes()...)
 	buf := make([]byte, len(syn))
 	ack := append(suite.cfg.network, suite.cfg.nonce...)
 
@@ -225,7 +228,8 @@ func (suite *AcceptorSuite) TestAcceptorAddPeerFails() {
 
 	// arrange
 	address := "136.44.33.12:5523"
-	nonce := uuid.NewV4().Bytes()
+	v4, _ := uuid.NewV4()
+	nonce := v4.Bytes()
 	syn := append(suite.cfg.network, nonce...)
 	buf := make([]byte, len(syn))
 	ack := append(suite.cfg.network, suite.cfg.nonce...)
@@ -265,7 +269,8 @@ func (suite *AcceptorSuite) TestAcceptorSuccess() {
 
 	// arrange
 	address := "136.44.33.12:5523"
-	nonce := uuid.NewV4().Bytes()
+	v4, _ := uuid.NewV4()
+	nonce := v4.Bytes()
 	syn := append(suite.cfg.network, nonce...)
 	buf := make([]byte, len(syn))
 	ack := append(suite.cfg.network, suite.cfg.nonce...)

--- a/network/connector_test.go
+++ b/network/connector_test.go
@@ -44,9 +44,10 @@ func (suite *ConnectorSuite) SetupTest() {
 	suite.log = zerolog.New(ioutil.Discard)
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
+	v4, _ := uuid.NewV4()
 	suite.cfg = Config{
 		network: Odin,
-		nonce:   uuid.NewV4().Bytes(),
+		nonce:   v4.Bytes(),
 	}
 }
 
@@ -170,7 +171,8 @@ func (suite *ConnectorSuite) TestConnectorNetworkMismatch() {
 	address := "136.44.33.12:5523"
 	syn := append(suite.cfg.network, suite.cfg.nonce...)
 	buf := make([]byte, len(syn))
-	ack := append([]byte{1, 2, 3, 4}, uuid.NewV4().Bytes()...)
+	v4, _ := uuid.NewV4()
+	ack := append([]byte{1, 2, 3, 4}, v4.Bytes()...)
 
 	conn := &ConnMock{}
 	conn.On("Write", syn).Return(len(syn), nil)
@@ -242,7 +244,8 @@ func (suite *ConnectorSuite) TestConnectorNonceKnown() {
 
 	// arrange
 	address := "136.44.33.12:5523"
-	nonce := uuid.NewV4().Bytes()
+	v4, _ := uuid.NewV4()
+	nonce := v4.Bytes()
 	syn := append(suite.cfg.network, suite.cfg.nonce...)
 	buf := make([]byte, len(syn))
 	ack := append(suite.cfg.network, nonce...)
@@ -281,7 +284,8 @@ func (suite *ConnectorSuite) TestConnectorAddPeerFails() {
 
 	// arrange
 	address := "136.44.33.12:5523"
-	nonce := uuid.NewV4().Bytes()
+	v4, _ := uuid.NewV4()
+	nonce := v4.Bytes()
 	syn := append(suite.cfg.network, suite.cfg.nonce...)
 	buf := make([]byte, len(syn))
 	ack := append(suite.cfg.network, nonce...)
@@ -320,7 +324,8 @@ func (suite *ConnectorSuite) TestConnectorSuccess() {
 
 	// arrange
 	address := "136.44.33.12:5523"
-	nonce := uuid.NewV4().Bytes()
+	v4, _ := uuid.NewV4()
+	nonce := v4.Bytes()
 	syn := append(suite.cfg.network, suite.cfg.nonce...)
 	buf := make([]byte, len(syn))
 	ack := append(suite.cfg.network, nonce...)

--- a/network/manager.go
+++ b/network/manager.go
@@ -61,6 +61,8 @@ func NewManager(log zerolog.Logger, codec Codec, options ...func(*Config)) *Mana
 	// initialize the package-wide waitgroup
 	wg := &sync.WaitGroup{}
 
+	v4, _ := uuid.NewV4()
+
 	// initialize the default configuration and apply custom options
 	cfg := &Config{
 		network:    Odin,
@@ -69,7 +71,7 @@ func NewManager(log zerolog.Logger, codec Codec, options ...func(*Config)) *Mana
 		minPeers:   3,
 		maxPeers:   10,
 		maxPending: 16,
-		nonce:      uuid.NewV4().Bytes(),
+		nonce:      v4.Bytes(),
 		interval:   time.Second * 1,
 		codec:      codec,
 		bufferSize: 16,


### PR DESCRIPTION
Due to the breaking API change, newV4() now returns multiple values. This PR is fixing that.