### PR TITLE
Add peer discovery when no addresses left to connect

### DIFF
--- a/network/dialer.go
+++ b/network/dialer.go
@@ -67,6 +67,7 @@ func handleDialing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers pe
 			byIPHash(sha256.New()),
 		)
 		if len(sample) == 0 {
+			handlers.Discoverer()
 			log.Info().Msg("could not get address to connect")
 			continue
 		}

--- a/network/dialer_test.go
+++ b/network/dialer_test.go
@@ -71,6 +71,7 @@ func (suite *DialerSuite) TestDialerSuccess() {
 
 	handlers := &HandlerManagerMock{}
 	handlers.On("Connector", address)
+	handlers.On("Discoverer")
 
 	// act
 	go handleDialing(suite.log, &suite.wg, &suite.cfg, peers, pending, addresses, rep, handlers, stop)
@@ -87,6 +88,7 @@ func (suite *DialerSuite) TestDialerSuccess() {
 		mock.AnythingOfType("func(string, string) bool"),
 	)
 	handlers.AssertCalled(suite.T(), "Connector", address)
+	handlers.AssertNotCalled(suite.T(), "Discoverer")
 }
 
 func (suite *DialerSuite) TestDialerNoAddresses() {
@@ -109,6 +111,7 @@ func (suite *DialerSuite) TestDialerNoAddresses() {
 
 	handlers := &HandlerManagerMock{}
 	handlers.On("Connector", mock.Anything)
+	handlers.On("Discoverer")
 
 	// act
 	go handleDialing(suite.log, &suite.wg, &suite.cfg, peers, pending, addresses, rep, handlers, stop)
@@ -125,6 +128,7 @@ func (suite *DialerSuite) TestDialerNoAddresses() {
 		mock.AnythingOfType("func(string, string) bool"),
 	)
 	handlers.AssertNotCalled(suite.T(), "Connector")
+	handlers.AssertCalled(suite.T(), "Discoverer")
 }
 
 func (suite *DialerSuite) TestDialerEnoughPeers() {
@@ -144,6 +148,7 @@ func (suite *DialerSuite) TestDialerEnoughPeers() {
 
 	handlers := &HandlerManagerMock{}
 	handlers.On("Connector", mock.Anything)
+	handlers.On("Discoverer")
 
 	// act
 	go handleDialing(suite.log, &suite.wg, &suite.cfg, peers, pending, addresses, rep, handlers, stop)
@@ -154,6 +159,7 @@ func (suite *DialerSuite) TestDialerEnoughPeers() {
 	// assert
 	addresses.AssertNotCalled(suite.T(), "Sample")
 	handlers.AssertNotCalled(suite.T(), "Connector")
+	handlers.AssertNotCalled(suite.T(), "Discoverer")
 }
 
 func (suite *DialerSuite) TestDialerMaximumPendingPeers() {
@@ -173,6 +179,7 @@ func (suite *DialerSuite) TestDialerMaximumPendingPeers() {
 
 	handlers := &HandlerManagerMock{}
 	handlers.On("Connector", mock.Anything)
+	handlers.On("Discoverer")
 
 	// act
 	go handleDialing(suite.log, &suite.wg, &suite.cfg, peers, pending, addresses, rep, handlers, stop)
@@ -183,4 +190,5 @@ func (suite *DialerSuite) TestDialerMaximumPendingPeers() {
 	// assert
 	addresses.AssertNotCalled(suite.T(), "Sample")
 	handlers.AssertNotCalled(suite.T(), "Connector")
+	handlers.AssertNotCalled(suite.T(), "Discoverer")
 }

--- a/network/discoverer.go
+++ b/network/discoverer.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"sync"
+
+	"github.com/rs/zerolog"
+)
+
+func handleDiscovering(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager) {
+	defer wg.Done()
+
+	// configure logger and add start/stop messages
+	log = log.With().Str("component", "discoverer").Logger()
+	log.Info().Msg("discovering routine started")
+	defer log.Info().Msg("discovering routine stopped")
+
+	// send a discover message to each peer
+	addresses := peers.Addresses()
+	if len(addresses) == 0 {
+		log.Info().Msg("could not launch discovery, no peers")
+		return
+	}
+
+	// get output for each peer and send the discover message
+	msg := &Discover{}
+	for _, address := range addresses {
+		output, err := peers.Output(address)
+		if err != nil {
+			log.Error().Err(err).Str("address", address).Msg("could not send discovery message")
+			continue
+		}
+		output <- msg
+	}
+}

--- a/network/discoverer_test.go
+++ b/network/discoverer_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"errors"
+	"io/ioutil"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestDiscoverer(t *testing.T) {
+	suite.Run(t, new(DiscovererSuite))
+}
+
+type DiscovererSuite struct {
+	suite.Suite
+	log zerolog.Logger
+	wg  sync.WaitGroup
+	cfg Config
+}
+
+func (suite *DiscovererSuite) SetupTest() {
+	suite.log = zerolog.New(ioutil.Discard)
+	suite.wg = sync.WaitGroup{}
+	suite.wg.Add(1)
+	suite.cfg = Config{}
+}
+
+func (suite *ConnectorSuite) TestDiscovererNoPeers() {
+
+	// arrange
+	closed := make(chan struct{})
+	close(closed)
+
+	peers := &PeerManagerMock{}
+	peers.On("Addresses").Return(nil)
+	peers.On("Output", mock.Anything).Return(closed, nil)
+
+	// act
+	handleDiscovering(suite.log, &suite.wg, &suite.cfg, peers)
+
+	// assert
+	peers.AssertCalled(suite.T(), "Addresses")
+	peers.AssertNotCalled(suite.T(), "Output")
+}
+
+func (suite *ConnectorSuite) TestDiscovererMissingOutput() {
+
+	// arrange
+	address1 := "192.0.2.10:1337"
+	address2 := "192.0.2.20:1337"
+	address3 := "192.0.2.30:1337"
+
+	output := make(chan interface{}, 3)
+
+	peers := &PeerManagerMock{}
+	peers.On("Addresses").Return([]string{address1, address2, address3})
+	peers.On("Output", address1).Return(output, nil)
+	peers.On("Output", address2).Return(nil, errors.New("could not get channel"))
+	peers.On("Output", address3).Return(output, nil)
+
+	// act
+	handleDiscovering(suite.log, &suite.wg, &suite.cfg, peers)
+	close(output)
+	var msgs []interface{}
+	for msg := range output {
+		msgs = append(msgs, msg)
+	}
+
+	// assert
+	peers.AssertCalled(suite.T(), "Addresses")
+	peers.AssertNumberOfCalls(suite.T(), "Output", 3)
+	if assert.Len(suite.T(), msgs, 2) {
+		assert.IsType(suite.T(), &Discover{}, msgs[0])
+		assert.IsType(suite.T(), &Discover{}, msgs[1])
+	}
+}
+
+func (suite *ConnectorSuite) TestDiscovererSuccess() {
+
+	// arrange
+	address1 := "192.0.2.10:1337"
+	address2 := "192.0.2.20:1337"
+	address3 := "192.0.2.30:1337"
+
+	output := make(chan interface{}, 3)
+
+	peers := &PeerManagerMock{}
+	peers.On("Addresses").Return([]string{address1, address2, address3})
+	peers.On("Output", address1).Return(output, nil)
+	peers.On("Output", address2).Return(output, nil)
+	peers.On("Output", address3).Return(output, nil)
+
+	// act
+	handleDiscovering(suite.log, &suite.wg, &suite.cfg, peers)
+	close(output)
+	var msgs []interface{}
+	for msg := range output {
+		msgs = append(msgs, msg)
+	}
+
+	// assert
+	peers.AssertCalled(suite.T(), "Addresses")
+	peers.AssertNumberOfCalls(suite.T(), "Output", 3)
+	if assert.Len(suite.T(), msgs, 3) {
+		assert.IsType(suite.T(), &Discover{}, msgs[0])
+		assert.IsType(suite.T(), &Discover{}, msgs[1])
+		assert.IsType(suite.T(), &Discover{}, msgs[2])
+	}
+}

--- a/network/handlerManager.go
+++ b/network/handlerManager.go
@@ -27,6 +27,7 @@ type handlerManager interface {
 	Server()
 	Dialer()
 	Listener()
+	Discoverer()
 	Acceptor(conn net.Conn)
 	Connector(address string)
 	Sender(address string, output <-chan interface{}, w io.Writer)

--- a/network/mocks_test.go
+++ b/network/mocks_test.go
@@ -280,6 +280,10 @@ func (hm *HandlerManagerMock) Listener() {
 	_ = hm.Called()
 }
 
+func (hm *HandlerManagerMock) Discoverer() {
+	_ = hm.Called()
+}
+
 func (hm *HandlerManagerMock) Acceptor(conn net.Conn) {
 	_ = hm.Called(conn)
 }

--- a/network/network.go
+++ b/network/network.go
@@ -141,6 +141,10 @@ func (net *simpleNetwork) Listener() {
 	go handleListening(net.log, net.wg, net.cfg, net, net.listener, net.stop)
 }
 
+func (net *simpleNetwork) Discoverer() {
+	go handleDiscovering(net.log, net.wg, net.cfg, net.peers)
+}
+
 func (net *simpleNetwork) Acceptor(conn net.Conn) {
 	go handleAccepting(net.log, net.wg, net.cfg, net.pending, net.peers, net.rep, conn)
 }

--- a/network/peerManager_test.go
+++ b/network/peerManager_test.go
@@ -138,3 +138,17 @@ func TestPeerManagerAddresses(t *testing.T) {
 	addresses = peers.Addresses()
 	assert.ElementsMatch(t, []string{address1, address2}, addresses)
 }
+
+func TestPeerManagerOutput(t *testing.T) {
+	peers := &simplePeerManager{reg: make(map[string]*peer)}
+
+	address := "192.0.2.100:1337"
+	_, err := peers.Output(address)
+	assert.NotNil(t, err)
+
+	p := &peer{output: make(chan interface{})}
+	peers.reg[address] = p
+	output, err := peers.Output(address)
+	assert.Nil(t, err)
+	assert.Equal(t, output, (chan<- interface{})(p.output))
+}


### PR DESCRIPTION
This PR will cause the client to send discovery messages to all connected peers if no eligible addresses are left when we try to connect to an additional peer. It does not solve the issue of needing some bootstrapping addresses to get started.