### PR TITLE
Implement rudimentary node

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,13 +29,13 @@
   branch = "master"
   name = "github.com/dgryski/go-farm"
   packages = ["."]
-  revision = "ac7624ea8da311f2fbbd94401d8c1cf66089f9fb"
+  revision = "2de33835d10275975374b37b2dcfd22c9020a1f5"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/pierrec/lz4"
@@ -64,14 +64,14 @@
 [[projects]]
   name = "github.com/rs/zerolog"
   packages = [".","internal/json"]
-  revision = "3ac71fc58dbd43122668a912b755b0979ba9ce1f"
-  version = "v1.3.0"
+  revision = "b53826c57a6a1d8833443ebeacf1cfb62b229c64"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/stretchr/objx"
@@ -82,8 +82,8 @@
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert","mock","require","suite"]
-  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
-  version = "v1.2.0"
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
@@ -101,19 +101,19 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["blake2b","pbkdf2"]
-  revision = "d585fd2cc9195196078f516b69daff6744ef5e84"
+  revision = "9de5f2eaf759b4c4550b3db39fed2e9e5f86f45c"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","internal/timeseries","trace"]
-  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+  revision = "f5dfe339be1d06f81b22525fe34671ee7d2c8904"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "d818ba11af4465e00c1998bd3f8a55603b422290"
+  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
   name = "zombiezen.com/go/capnproto2"
@@ -124,6 +124,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0937aa257df00d126f0621a121a4261d66dd59ad43e96f03c50d94cf1048134a"
+  inputs-digest = "dd641513d047e776044f2ddef292bc13ff41e29e1148d3598131164bebe8a934"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -74,6 +74,12 @@
   version = "v1.2.0"
 
 [[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/stretchr/objx"
   packages = ["."]
   revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
@@ -124,6 +130,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dd641513d047e776044f2ddef292bc13ff41e29e1148d3598131164bebe8a934"
+  inputs-digest = "adb5d6498d7cf1f9a28453b0ac06d7fa204c276ac42cc721463dd93fa4d81b47"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,15 +39,15 @@
 
 [[constraint]]
   name = "github.com/rs/zerolog"
-  version = "1.3.0"
+  version = "1.4.0"
 
 [[constraint]]
   name = "github.com/satori/go.uuid"
-  version = "1.1.0"
+  version = "1.2.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.1.4"
+  version = "1.2.1"
 
 [[constraint]]
   branch = "master"

--- a/config.go
+++ b/config.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import "net"
+
+// DefaultConfig sets the default configuration parameters for our node.
+var DefaultConfig = Config{
+	Listen: true,
+	IP:     net.IPv4(127, 0, 0, 1),
+	Port:   21517,
+	Bootstrap: []string{
+		"127.0.0.1:21517",
+	},
+}
+
+// Config represents the configuration of the Alvalor node.
+type Config struct {
+	Listen    bool
+	IP        net.IP
+	Port      uint16
+	Bootstrap []string
+}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 
 	// apply the command line parameters to configuration
 	pflag.Uint16Var(&cfg.Port, "port", 21517, "listen port for incoming connections")
+	pflag.Parse()
 
 	// seed the random generator
 	rand.Seed(time.Now().UnixNano())
@@ -56,7 +57,13 @@ func main() {
 	net := network.New(log, cod,
 		network.SetListen(cfg.Listen),
 		network.SetAddress(fmt.Sprintf("%v:%v", cfg.IP, cfg.Port)),
+		network.SetMinPeers(1),
 	)
+
+	// add the bootstrapping nodes
+	for _, address := range cfg.Bootstrap {
+		net.Add(address)
+	}
 
 	// wait for a stop signal to initialize shutdown
 	<-sig

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 		network.SetListen(cfg.Listen),
 		network.SetAddress(fmt.Sprintf("%v:%v", cfg.IP, cfg.Port)),
 		network.SetMinPeers(1),
+		network.SetMaxPeers(16),
 	)
 
 	// add the bootstrapping nodes

--- a/main.go
+++ b/main.go
@@ -18,12 +18,14 @@
 package main
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"os/signal"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
 
 	"github.com/alvalor/alvalor-go/codec"
 	"github.com/alvalor/alvalor-go/network"
@@ -35,6 +37,12 @@ func main() {
 	sig := make(chan os.Signal)
 	signal.Notify(sig, os.Interrupt)
 
+	// initialize default configuration
+	cfg := DefaultConfig
+
+	// apply the command line parameters to configuration
+	pflag.Uint16Var(&cfg.Port, "port", 21517, "listen port for incoming connections")
+
 	// seed the random generator
 	rand.Seed(time.Now().UnixNano())
 
@@ -45,7 +53,10 @@ func main() {
 	cod := codec.NewProto()
 
 	// initialize the network component to create our p2p network node
-	net := network.New(log, cod)
+	net := network.New(log, cod,
+		network.SetListen(cfg.Listen),
+		network.SetAddress(fmt.Sprintf("%v:%v", cfg.IP, cfg.Port)),
+	)
 
 	// wait for a stop signal to initialize shutdown
 	<-sig

--- a/main.go
+++ b/main.go
@@ -54,14 +54,16 @@ func main() {
 	cod := codec.NewProto()
 
 	// initialize the network component to create our p2p network node
+	address := fmt.Sprintf("%v:%v", cfg.IP, cfg.Port)
 	net := network.New(log, cod,
 		network.SetListen(cfg.Listen),
-		network.SetAddress(fmt.Sprintf("%v:%v", cfg.IP, cfg.Port)),
+		network.SetAddress(address),
 		network.SetMinPeers(1),
 		network.SetMaxPeers(16),
 	)
 
-	// add the bootstrapping nodes
+	// add own address & bootstrapping nodes
+	net.Add(address)
 	for _, address := range cfg.Bootstrap {
 		net.Add(address)
 	}

--- a/network/acceptor_test.go
+++ b/network/acceptor_test.go
@@ -69,8 +69,10 @@ func (suite *AcceptorSuite) TestAcceptorClaimFails() {
 
 	rep := &ReputationManagerMock{}
 
+	book := &AddressManagerMock{}
+
 	// act
-	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, conn)
+	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -101,8 +103,10 @@ func (suite *AcceptorSuite) TestAcceptorReadFails() {
 	rep := &ReputationManagerMock{}
 	rep.On("Error", address)
 
+	book := &AddressManagerMock{}
+
 	// act
-	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, conn)
+	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -137,8 +141,10 @@ func (suite *AcceptorSuite) TestAcceptorNetworkMismatch() {
 	rep := &ReputationManagerMock{}
 	rep.On("Invalid", address)
 
+	book := &AddressManagerMock{}
+
 	// act
-	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, conn)
+	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -173,8 +179,10 @@ func (suite *AcceptorSuite) TestAcceptorNonceIdentical() {
 	rep := &ReputationManagerMock{}
 	rep.On("Invalid", address)
 
+	book := &AddressManagerMock{}
+
 	// act
-	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, conn)
+	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -211,8 +219,10 @@ func (suite *AcceptorSuite) TestAcceptorWriteFails() {
 	rep := &ReputationManagerMock{}
 	rep.On("Error", address)
 
+	book := &AddressManagerMock{}
+
 	// act
-	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, conn)
+	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -252,8 +262,10 @@ func (suite *AcceptorSuite) TestAcceptorAddPeerFails() {
 	conn.On("Write", ack).Return(len(ack), nil)
 	conn.On("Close").Return(nil)
 
+	book := &AddressManagerMock{}
+
 	// act
-	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, conn)
+	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -291,8 +303,10 @@ func (suite *AcceptorSuite) TestAcceptorSuccess() {
 	rep := &ReputationManagerMock{}
 	rep.On("Success", address)
 
+	book := &AddressManagerMock{}
+
 	// act
-	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, conn)
+	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)

--- a/network/acceptor_test.go
+++ b/network/acceptor_test.go
@@ -94,8 +94,8 @@ func (suite *AcceptorSuite) TestAcceptorSuccess() {
 	rep.AssertCalled(t, "Success", address)
 
 	conn.AssertNotCalled(t, "Close")
-	rep.AssertNotCalled(t, "Failure")
-	book.AssertNotCalled(t, "Block")
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *AcceptorSuite) TestAcceptorClaimFails() {
@@ -139,11 +139,11 @@ func (suite *AcceptorSuite) TestAcceptorClaimFails() {
 	pending.AssertCalled(t, "Claim", address)
 	conn.AssertCalled(t, "Close")
 
-	pending.AssertNotCalled(t, "Release")
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
-	rep.AssertNotCalled(t, "Failure")
-	book.AssertNotCalled(t, "Block")
+	pending.AssertNotCalled(t, "Release", mock.Anything)
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *AcceptorSuite) TestAcceptorReadFails() {
@@ -189,9 +189,9 @@ func (suite *AcceptorSuite) TestAcceptorReadFails() {
 	rep.AssertCalled(t, "Failure", address)
 	conn.AssertCalled(t, "Close")
 
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
-	book.AssertNotCalled(t, "Block")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *AcceptorSuite) TestAcceptorNetworkMismatch() {
@@ -237,9 +237,9 @@ func (suite *AcceptorSuite) TestAcceptorNetworkMismatch() {
 	book.AssertCalled(t, "Block", address)
 	conn.AssertCalled(t, "Close")
 
-	rep.AssertNotCalled(t, "Success")
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Failure")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
 }
 
 func (suite *AcceptorSuite) TestAcceptorNonceIdentical() {
@@ -284,9 +284,9 @@ func (suite *AcceptorSuite) TestAcceptorNonceIdentical() {
 	book.AssertCalled(t, "Block", address)
 	conn.AssertCalled(t, "Close")
 
-	rep.AssertNotCalled(t, "Success")
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Failure")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
 }
 
 func (suite *AcceptorSuite) TestAcceptorWriteFails() {
@@ -332,9 +332,9 @@ func (suite *AcceptorSuite) TestAcceptorWriteFails() {
 	rep.AssertCalled(t, "Failure", address)
 	conn.AssertCalled(t, "Close")
 
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
-	book.AssertNotCalled(t, "Block")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *AcceptorSuite) TestAcceptorAddPeerFails() {
@@ -380,7 +380,7 @@ func (suite *AcceptorSuite) TestAcceptorAddPeerFails() {
 	peers.AssertCalled(t, "Add", conn, nonce)
 	conn.AssertCalled(t, "Close")
 
-	rep.AssertNotCalled(t, "Success")
-	rep.AssertNotCalled(t, "Failure")
-	book.AssertNotCalled(t, "Block")
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }

--- a/network/acceptor_test.go
+++ b/network/acceptor_test.go
@@ -54,103 +54,144 @@ func (suite *AcceptorSuite) TestAcceptorClaimFails() {
 
 	// arrange
 	address := "192.0.2.100:1337"
+	nonce := uuid.NewV4().Bytes()
+	syn := append(suite.cfg.network, nonce...)
 
 	addr := &AddrMock{}
 	addr.On("String").Return(address)
 
 	conn := &ConnMock{}
 	conn.On("RemoteAddr").Return(addr)
+	conn.On("Read", mock.Anything).Run(func(args mock.Arguments) {
+		copy(args.Get(0).([]byte), syn)
+	}).Return(0, nil)
+	conn.On("Write", mock.Anything).Return(0, nil)
 	conn.On("Close").Return(nil)
 
 	pending := &PendingManagerMock{}
-	pending.On("Claim", address).Return(errors.New("cannot claim slot"))
+	pending.On("Claim", mock.Anything).Return(errors.New("could not claim slot"))
+	pending.On("Release", mock.Anything).Return(nil)
 
 	peers := &PeerManagerMock{}
+	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
 
 	rep := &ReputationManagerMock{}
+	rep.On("Failure", mock.Anything)
+	rep.On("Success", mock.Anything)
 
 	book := &AddressManagerMock{}
+	book.On("Block", mock.Anything)
 
 	// act
 	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
-	pending.AssertCalled(suite.T(), "Claim", address)
-	pending.AssertNotCalled(suite.T(), "Release", address)
-	conn.AssertCalled(suite.T(), "Close")
+	t := suite.T()
+
+	pending.AssertCalled(t, "Claim", address)
+	conn.AssertCalled(t, "Close")
+
+	pending.AssertNotCalled(t, "Release")
+	peers.AssertNotCalled(t, "Add")
+	rep.AssertNotCalled(t, "Success")
+	rep.AssertNotCalled(t, "Failure")
+	book.AssertNotCalled(t, "Block")
 }
 
 func (suite *AcceptorSuite) TestAcceptorReadFails() {
 
 	// arrange
 	address := "192.0.2.100:1337"
-	buf := make([]byte, len(suite.cfg.network)+len(suite.cfg.nonce))
+	nonce := uuid.NewV4().Bytes()
+	syn := append(suite.cfg.network, nonce...)
 
 	addr := &AddrMock{}
 	addr.On("String").Return(address)
 
 	conn := &ConnMock{}
 	conn.On("RemoteAddr").Return(addr)
-	conn.On("Read", buf).Return(1, errors.New("cannot read from connection"))
+	conn.On("Read", mock.Anything).Run(func(args mock.Arguments) {
+		copy(args.Get(0).([]byte), syn)
+	}).Return(0, errors.New("could not read syn"))
+	conn.On("Write", mock.Anything).Return(0, nil)
 	conn.On("Close").Return(nil)
 
 	pending := &PendingManagerMock{}
-	pending.On("Claim", address).Return(nil)
-	pending.On("Release", address).Return(nil)
+	pending.On("Claim", mock.Anything).Return(nil)
+	pending.On("Release", mock.Anything).Return(nil)
 
 	peers := &PeerManagerMock{}
+	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
 
 	rep := &ReputationManagerMock{}
-	rep.On("Error", address)
+	rep.On("Failure", mock.Anything)
+	rep.On("Success", mock.Anything)
 
 	book := &AddressManagerMock{}
+	book.On("Block", mock.Anything)
 
 	// act
 	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
-	pending.AssertCalled(suite.T(), "Claim", address)
-	pending.AssertCalled(suite.T(), "Release", address)
-	rep.AssertCalled(suite.T(), "Error", address)
-	conn.AssertCalled(suite.T(), "Close")
+	t := suite.T()
+
+	pending.AssertCalled(t, "Claim", address)
+	pending.AssertCalled(t, "Release", address)
+	rep.AssertCalled(t, "Failure", address)
+	conn.AssertCalled(t, "Close")
+
+	peers.AssertNotCalled(t, "Add")
+	rep.AssertNotCalled(t, "Success")
+	book.AssertNotCalled(t, "Block")
 }
 
 func (suite *AcceptorSuite) TestAcceptorNetworkMismatch() {
 
 	// arrange
 	address := "192.0.2.100:1337"
-	syn := append([]byte{1, 2, 3, 4}, uuid.NewV4().Bytes()...)
-	buf := make([]byte, len(syn))
+	nonce := uuid.NewV4().Bytes()
+	syn := append([]byte{1, 2, 3, 4}, nonce...)
 
 	addr := &AddrMock{}
 	addr.On("String").Return(address)
 
 	conn := &ConnMock{}
 	conn.On("RemoteAddr").Return(addr)
-	conn.On("Read", buf).Run(func(args mock.Arguments) {
+	conn.On("Read", mock.Anything).Run(func(args mock.Arguments) {
 		copy(args.Get(0).([]byte), syn)
-	}).Return(len(buf), nil)
+	}).Return(0, nil)
+	conn.On("Write", mock.Anything).Return(0, nil)
 	conn.On("Close").Return(nil)
 
 	pending := &PendingManagerMock{}
-	pending.On("Claim", address).Return(nil)
-	pending.On("Release", address).Return(nil)
+	pending.On("Claim", mock.Anything).Return(nil)
+	pending.On("Release", mock.Anything).Return(nil)
 
 	peers := &PeerManagerMock{}
+	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
 
 	rep := &ReputationManagerMock{}
-	rep.On("Invalid", address)
+	rep.On("Failure", mock.Anything)
+	rep.On("Success", mock.Anything)
 
 	book := &AddressManagerMock{}
+	book.On("Block", mock.Anything)
 
 	// act
 	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
-	pending.AssertCalled(suite.T(), "Claim", address)
-	pending.AssertCalled(suite.T(), "Release", address)
-	rep.AssertCalled(suite.T(), "Invalid", address)
-	conn.AssertCalled(suite.T(), "Close")
+	t := suite.T()
+
+	pending.AssertCalled(t, "Claim", address)
+	pending.AssertCalled(t, "Release", address)
+	book.AssertCalled(t, "Block", address)
+	conn.AssertCalled(t, "Close")
+
+	rep.AssertNotCalled(t, "Success")
+	peers.AssertNotCalled(t, "Add")
+	rep.AssertNotCalled(t, "Failure")
 }
 
 func (suite *AcceptorSuite) TestAcceptorNonceIdentical() {
@@ -158,77 +199,94 @@ func (suite *AcceptorSuite) TestAcceptorNonceIdentical() {
 	// arrange
 	address := "192.0.2.100:1337"
 	syn := append(suite.cfg.network, suite.cfg.nonce...)
-	buf := make([]byte, len(syn))
 
 	addr := &AddrMock{}
 	addr.On("String").Return(address)
 
 	conn := &ConnMock{}
 	conn.On("RemoteAddr").Return(addr)
-	conn.On("Read", buf).Run(func(args mock.Arguments) {
+	conn.On("Read", mock.Anything).Run(func(args mock.Arguments) {
 		copy(args.Get(0).([]byte), syn)
-	}).Return(len(buf), nil)
+	}).Return(0, nil)
+	conn.On("Write", mock.Anything).Return(0, nil)
 	conn.On("Close").Return(nil)
 
 	pending := &PendingManagerMock{}
-	pending.On("Claim", address).Return(nil)
-	pending.On("Release", address).Return(nil)
+	pending.On("Claim", mock.Anything).Return(nil)
+	pending.On("Release", mock.Anything).Return(nil)
 
 	peers := &PeerManagerMock{}
+	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
 
 	rep := &ReputationManagerMock{}
-	rep.On("Invalid", address)
+	rep.On("Failure", mock.Anything)
+	rep.On("Success", mock.Anything)
 
 	book := &AddressManagerMock{}
+	book.On("Block", mock.Anything)
 
 	// act
 	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
-	pending.AssertCalled(suite.T(), "Claim", address)
-	pending.AssertCalled(suite.T(), "Release", address)
-	rep.AssertCalled(suite.T(), "Invalid", address)
-	conn.AssertCalled(suite.T(), "Close")
+	t := suite.T()
+
+	pending.AssertCalled(t, "Claim", address)
+	pending.AssertCalled(t, "Release", address)
+	book.AssertCalled(t, "Block", address)
+	conn.AssertCalled(t, "Close")
+
+	rep.AssertNotCalled(t, "Success")
+	peers.AssertNotCalled(t, "Add")
+	rep.AssertNotCalled(t, "Failure")
 }
 
 func (suite *AcceptorSuite) TestAcceptorWriteFails() {
 
 	// arrange
 	address := "192.0.2.100:1337"
-	syn := append(suite.cfg.network, uuid.NewV4().Bytes()...)
-	buf := make([]byte, len(syn))
-	ack := append(suite.cfg.network, suite.cfg.nonce...)
+	nonce := uuid.NewV4().Bytes()
+	syn := append(suite.cfg.network, nonce...)
 
 	addr := &AddrMock{}
 	addr.On("String").Return(address)
 
 	conn := &ConnMock{}
 	conn.On("RemoteAddr").Return(addr)
-	conn.On("Read", buf).Run(func(args mock.Arguments) {
+	conn.On("Read", mock.Anything).Run(func(args mock.Arguments) {
 		copy(args.Get(0).([]byte), syn)
-	}).Return(len(buf), nil)
-	conn.On("Write", ack).Return(0, errors.New("cannot write to connection"))
+	}).Return(0, nil)
+	conn.On("Write", mock.Anything).Return(0, errors.New("could not write ack"))
 	conn.On("Close").Return(nil)
 
 	pending := &PendingManagerMock{}
-	pending.On("Claim", address).Return(nil)
-	pending.On("Release", address).Return(nil)
+	pending.On("Claim", mock.Anything).Return(nil)
+	pending.On("Release", mock.Anything).Return(nil)
 
 	peers := &PeerManagerMock{}
+	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
 
 	rep := &ReputationManagerMock{}
-	rep.On("Error", address)
+	rep.On("Failure", mock.Anything)
+	rep.On("Success", mock.Anything)
 
 	book := &AddressManagerMock{}
+	book.On("Block", mock.Anything)
 
 	// act
 	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
-	pending.AssertCalled(suite.T(), "Claim", address)
-	pending.AssertCalled(suite.T(), "Release", address)
-	rep.AssertCalled(suite.T(), "Error", address)
-	conn.AssertCalled(suite.T(), "Close")
+	t := suite.T()
+
+	pending.AssertCalled(t, "Claim", address)
+	pending.AssertCalled(t, "Release", address)
+	rep.AssertCalled(t, "Failure", address)
+	conn.AssertCalled(t, "Close")
+
+	peers.AssertNotCalled(t, "Add")
+	rep.AssertNotCalled(t, "Success")
+	book.AssertNotCalled(t, "Block")
 }
 
 func (suite *AcceptorSuite) TestAcceptorAddPeerFails() {
@@ -237,40 +295,46 @@ func (suite *AcceptorSuite) TestAcceptorAddPeerFails() {
 	address := "192.0.2.100:1337"
 	nonce := uuid.NewV4().Bytes()
 	syn := append(suite.cfg.network, nonce...)
-	buf := make([]byte, len(syn))
-	ack := append(suite.cfg.network, suite.cfg.nonce...)
 
 	addr := &AddrMock{}
 	addr.On("String").Return(address)
 
 	conn := &ConnMock{}
 	conn.On("RemoteAddr").Return(addr)
-
-	pending := &PendingManagerMock{}
-	pending.On("Claim", address).Return(nil)
-	pending.On("Release", address).Return(nil)
-
-	peers := &PeerManagerMock{}
-	peers.On("Add", conn, nonce).Return(errors.New("cannot add peer"))
-
-	rep := &ReputationManagerMock{}
-	rep.On("Error", address)
-
-	conn.On("Read", buf).Run(func(args mock.Arguments) {
+	conn.On("Read", mock.Anything).Run(func(args mock.Arguments) {
 		copy(args.Get(0).([]byte), syn)
-	}).Return(len(buf), nil)
-	conn.On("Write", ack).Return(len(ack), nil)
+	}).Return(0, nil)
+	conn.On("Write", mock.Anything).Return(0, nil)
 	conn.On("Close").Return(nil)
 
+	pending := &PendingManagerMock{}
+	pending.On("Claim", mock.Anything).Return(nil)
+	pending.On("Release", mock.Anything).Return(nil)
+
+	peers := &PeerManagerMock{}
+	peers.On("Add", mock.Anything, mock.Anything).Return(errors.New("could not add peer"))
+
+	rep := &ReputationManagerMock{}
+	rep.On("Failure", mock.Anything)
+	rep.On("Success", mock.Anything)
+
 	book := &AddressManagerMock{}
+	book.On("Block", mock.Anything)
 
 	// act
 	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
-	pending.AssertCalled(suite.T(), "Claim", address)
-	pending.AssertCalled(suite.T(), "Release", address)
-	conn.AssertCalled(suite.T(), "Close")
+	t := suite.T()
+
+	pending.AssertCalled(t, "Claim", address)
+	pending.AssertCalled(t, "Release", address)
+	peers.AssertCalled(t, "Add", conn, nonce)
+	conn.AssertCalled(t, "Close")
+
+	rep.AssertNotCalled(t, "Success")
+	rep.AssertNotCalled(t, "Failure")
+	book.AssertNotCalled(t, "Block")
 }
 
 func (suite *AcceptorSuite) TestAcceptorSuccess() {
@@ -279,38 +343,44 @@ func (suite *AcceptorSuite) TestAcceptorSuccess() {
 	address := "192.0.2.100:1337"
 	nonce := uuid.NewV4().Bytes()
 	syn := append(suite.cfg.network, nonce...)
-	buf := make([]byte, len(syn))
-	ack := append(suite.cfg.network, suite.cfg.nonce...)
 
 	addr := &AddrMock{}
 	addr.On("String").Return(address)
 
 	conn := &ConnMock{}
 	conn.On("RemoteAddr").Return(addr)
-	conn.On("Read", buf).Run(func(args mock.Arguments) {
+	conn.On("Read", mock.Anything).Run(func(args mock.Arguments) {
 		copy(args.Get(0).([]byte), syn)
-	}).Return(len(buf), nil)
-	conn.On("Write", ack).Return(len(ack), nil)
+	}).Return(0, nil)
+	conn.On("Write", mock.Anything).Return(0, nil)
 	conn.On("Close").Return(nil)
 
 	pending := &PendingManagerMock{}
-	pending.On("Claim", address).Return(nil)
-	pending.On("Release", address).Return(nil)
+	pending.On("Claim", mock.Anything).Return(nil)
+	pending.On("Release", mock.Anything).Return(nil)
 
 	peers := &PeerManagerMock{}
-	peers.On("Add", conn, nonce).Return(nil)
+	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
 
 	rep := &ReputationManagerMock{}
-	rep.On("Success", address)
+	rep.On("Failure", mock.Anything)
+	rep.On("Success", mock.Anything)
 
 	book := &AddressManagerMock{}
+	book.On("Block", mock.Anything)
 
 	// act
 	handleAccepting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, conn)
 
 	// assert
-	pending.AssertCalled(suite.T(), "Claim", address)
-	pending.AssertCalled(suite.T(), "Release", address)
-	peers.AssertCalled(suite.T(), "Add", conn, nonce)
-	rep.AssertCalled(suite.T(), "Success", address)
+	t := suite.T()
+
+	pending.AssertCalled(t, "Claim", address)
+	pending.AssertCalled(t, "Release", address)
+	peers.AssertCalled(t, "Add", conn, nonce)
+	rep.AssertCalled(t, "Success", address)
+
+	conn.AssertNotCalled(t, "Close")
+	rep.AssertNotCalled(t, "Failure")
+	book.AssertNotCalled(t, "Block")
 }

--- a/network/connector.go
+++ b/network/connector.go
@@ -19,12 +19,13 @@ package network
 
 import (
 	"bytes"
+	"encoding/hex"
 	"sync"
 
 	"github.com/rs/zerolog"
 )
 
-func handleConnecting(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, pending pendingManager, peers peerManager, rep reputationManager, dialer dialWrapper, address string) {
+func handleConnecting(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, pending pendingManager, peers peerManager, rep reputationManager, book addressManager, dialer dialWrapper, address string) {
 	defer wg.Done()
 
 	// extract the variables from the config we are interested in
@@ -61,34 +62,34 @@ func handleConnecting(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, pendi
 	if err != nil {
 		log.Error().Err(err).Msg("could not write syn packet")
 		conn.Close()
-		rep.Error(address)
+		rep.Failure(address)
 		return
 	}
 	_, err = conn.Read(ack)
 	if err != nil {
 		log.Error().Err(err).Msg("could not read ack packet")
 		conn.Close()
-		rep.Error(address)
+		rep.Failure(address)
 		return
 	}
 	networkIn := ack[:len(network)]
 	if !bytes.Equal(networkIn, network) {
 		log.Error().Bytes("network", network).Bytes("network_in", networkIn).Msg("network mismatch")
 		conn.Close()
-		rep.Invalid(address)
+		book.Block(address)
 		return
 	}
 	nonceIn := ack[len(network):]
 	if bytes.Equal(nonceIn, nonce) {
-		log.Error().Bytes("nonce", nonce).Msg("identical nonce")
+		log.Error().Str("nonce", hex.EncodeToString(nonce)).Msg("identical nonce")
 		conn.Close()
-		rep.Invalid(address)
+		book.Block(address)
 		return
 	}
 	if peers.Known(nonceIn) {
-		log.Error().Bytes("nonce", nonce).Msg("nonce already known")
+		log.Error().Str("nonce", hex.EncodeToString(nonce)).Msg("nonce already known")
 		conn.Close()
-		rep.Invalid(address)
+		book.Block(address)
 		return
 	}
 

--- a/network/connector_test.go
+++ b/network/connector_test.go
@@ -45,7 +45,7 @@ func (suite *ConnectorSuite) SetupTest() {
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
 	suite.cfg = Config{
-		network: Odin,
+		network: []byte{1, 3, 3, 7},
 		nonce:   uuid.NewV4().Bytes(),
 	}
 }
@@ -237,8 +237,8 @@ func (suite *ConnectorSuite) TestConnectorWriteFails() {
 	conn.AssertCalled(t, "Close")
 	rep.AssertCalled(t, "Failure", address)
 
-	peers.AssertCalled(t, "Add")
-	rep.AssertCalled(t, "Success")
+	peers.AssertNotCalled(t, "Add")
+	rep.AssertNotCalled(t, "Success")
 	book.AssertNotCalled(t, "Block")
 }
 
@@ -404,7 +404,7 @@ func (suite *ConnectorSuite) TestConnectorNonceKnown() {
 	rep.On("Failure", mock.Anything)
 
 	peers := &PeerManagerMock{}
-	peers.On("Known", mock.Anything).Return(false)
+	peers.On("Known", mock.Anything).Return(true)
 	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
 
 	pending := &PendingManagerMock{}
@@ -453,7 +453,7 @@ func (suite *ConnectorSuite) TestConnectorAddPeerFails() {
 
 	peers := &PeerManagerMock{}
 	peers.On("Known", mock.Anything).Return(false)
-	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
+	peers.On("Add", mock.Anything, mock.Anything).Return(errors.New("could not add peer"))
 
 	pending := &PendingManagerMock{}
 	pending.On("Claim", mock.Anything).Return(nil)

--- a/network/connector_test.go
+++ b/network/connector_test.go
@@ -62,10 +62,12 @@ func (suite *ConnectorSuite) TestConnectorClaimFails() {
 
 	rep := &ReputationManagerMock{}
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -86,11 +88,13 @@ func (suite *ConnectorSuite) TestConnectorDialFails() {
 	pending.On("Claim", address).Return(nil)
 	pending.On("Release", address).Return(nil)
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 	dialer.On("Dial", address).Return(nil, errors.New("cannot dial address"))
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -117,11 +121,13 @@ func (suite *ConnectorSuite) TestConnectorWriteFails() {
 	pending.On("Claim", address).Return(nil)
 	pending.On("Release", address).Return(nil)
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 	dialer.On("Dial", address).Return(conn, nil)
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -151,11 +157,13 @@ func (suite *ConnectorSuite) TestConnectorReadFails() {
 	pending.On("Claim", address).Return(nil)
 	pending.On("Release", address).Return(nil)
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 	dialer.On("Dial", address).Return(conn, nil)
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -188,11 +196,13 @@ func (suite *ConnectorSuite) TestConnectorNetworkMismatch() {
 	pending.On("Claim", address).Return(nil)
 	pending.On("Release", address).Return(nil)
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 	dialer.On("Dial", address).Return(conn, nil)
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -225,11 +235,13 @@ func (suite *ConnectorSuite) TestConnectorNonceIdentical() {
 	pending.On("Claim", address).Return(nil)
 	pending.On("Release", address).Return(nil)
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 	dialer.On("Dial", address).Return(conn, nil)
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -264,11 +276,13 @@ func (suite *ConnectorSuite) TestConnectorNonceKnown() {
 	pending.On("Claim", address).Return(nil)
 	pending.On("Release", address).Return(nil)
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 	dialer.On("Dial", address).Return(conn, nil)
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -304,11 +318,13 @@ func (suite *ConnectorSuite) TestConnectorAddPeerFails() {
 	pending.On("Claim", address).Return(nil)
 	pending.On("Release", address).Return(nil)
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 	dialer.On("Dial", address).Return(conn, nil)
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)
@@ -343,11 +359,13 @@ func (suite *ConnectorSuite) TestConnectorSuccess() {
 	pending.On("Claim", address).Return(nil)
 	pending.On("Release", address).Return(nil)
 
+	book := &AddressManagerMock{}
+
 	dialer := &DialManagerMock{}
 	dialer.On("Dial", address).Return(conn, nil)
 
 	// act
-	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, dialer, address)
+	handleConnecting(suite.log, &suite.wg, &suite.cfg, pending, peers, rep, book, dialer, address)
 
 	// assert
 	pending.AssertCalled(suite.T(), "Claim", address)

--- a/network/connector_test.go
+++ b/network/connector_test.go
@@ -94,8 +94,8 @@ func (suite *ConnectorSuite) TestConnectorSuccess() {
 	rep.AssertCalled(t, "Success", address)
 
 	conn.AssertNotCalled(t, "Close")
-	rep.AssertNotCalled(t, "Failure")
-	book.AssertNotCalled(t, "Block")
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *ConnectorSuite) TestConnectorClaimFails() {

--- a/network/connector_test.go
+++ b/network/connector_test.go
@@ -121,7 +121,7 @@ func (suite *ConnectorSuite) TestConnectorClaimFails() {
 	peers.On("Add", mock.Anything, mock.Anything).Return(nil)
 
 	pending := &PendingManagerMock{}
-	pending.On("Claim", mock.Anything).Return(nil)
+	pending.On("Claim", mock.Anything).Return(errors.New("could not claim slot"))
 	pending.On("Release", mock.Anything).Return(nil)
 
 	book := &AddressManagerMock{}
@@ -138,12 +138,12 @@ func (suite *ConnectorSuite) TestConnectorClaimFails() {
 
 	pending.AssertCalled(t, "Claim", address)
 
-	pending.AssertNotCalled(t, "Release")
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
+	pending.AssertNotCalled(t, "Release", mock.Anything)
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
 	conn.AssertNotCalled(t, "Close")
-	rep.AssertNotCalled(t, "Failure")
-	book.AssertNotCalled(t, "Block")
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *ConnectorSuite) TestConnectorDialFails() {
@@ -188,10 +188,10 @@ func (suite *ConnectorSuite) TestConnectorDialFails() {
 	pending.AssertCalled(t, "Release", address)
 	rep.AssertCalled(t, "Failure", address)
 
-	peers.AssertNotCalled(t, "Add", conn, nonce)
-	rep.AssertNotCalled(t, "Success", address)
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
 	conn.AssertNotCalled(t, "Close")
-	book.AssertNotCalled(t, "Block")
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *ConnectorSuite) TestConnectorWriteFails() {
@@ -237,9 +237,9 @@ func (suite *ConnectorSuite) TestConnectorWriteFails() {
 	conn.AssertCalled(t, "Close")
 	rep.AssertCalled(t, "Failure", address)
 
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
-	book.AssertNotCalled(t, "Block")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *ConnectorSuite) TestConnectorReadFails() {
@@ -285,9 +285,9 @@ func (suite *ConnectorSuite) TestConnectorReadFails() {
 	conn.AssertCalled(t, "Close")
 	rep.AssertCalled(t, "Failure", address)
 
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
-	book.AssertNotCalled(t, "Block")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }
 
 func (suite *ConnectorSuite) TestConnectorNetworkMismatch() {
@@ -333,9 +333,9 @@ func (suite *ConnectorSuite) TestConnectorNetworkMismatch() {
 	conn.AssertCalled(t, "Close")
 	book.AssertCalled(t, "Block", address)
 
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
-	rep.AssertNotCalled(t, "Failure")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
 }
 
 func (suite *ConnectorSuite) TestConnectorNonceIdentical() {
@@ -380,9 +380,9 @@ func (suite *ConnectorSuite) TestConnectorNonceIdentical() {
 	conn.AssertCalled(t, "Close")
 	book.AssertCalled(t, "Block", address)
 
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
-	rep.AssertNotCalled(t, "Failure")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
 }
 
 func (suite *ConnectorSuite) TestConnectorNonceKnown() {
@@ -428,9 +428,9 @@ func (suite *ConnectorSuite) TestConnectorNonceKnown() {
 	conn.AssertCalled(t, "Close")
 	book.AssertCalled(t, "Block", address)
 
-	peers.AssertNotCalled(t, "Add")
-	rep.AssertNotCalled(t, "Success")
-	rep.AssertNotCalled(t, "Failure")
+	peers.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
 }
 
 func (suite *ConnectorSuite) TestConnectorAddPeerFails() {
@@ -476,7 +476,7 @@ func (suite *ConnectorSuite) TestConnectorAddPeerFails() {
 	peers.AssertCalled(t, "Add", conn, nonce)
 	conn.AssertCalled(t, "Close")
 
-	book.AssertNotCalled(t, "Block")
-	rep.AssertNotCalled(t, "Success")
-	rep.AssertNotCalled(t, "Failure")
+	rep.AssertNotCalled(t, "Success", mock.Anything)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
+	book.AssertNotCalled(t, "Block", mock.Anything)
 }

--- a/network/dialer.go
+++ b/network/dialer.go
@@ -58,8 +58,9 @@ func handleDialing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers pe
 			isNot([]string{address}),
 			isNot(pending.Addresses()),
 			isNot(peers.Addresses()),
-			isAbove(rep, -5),
-			byReputation(rep),
+			isScoreAbove(rep, -5),
+			isLastBefore(rep, time.Now().Add(-15*time.Minute)),
+			byScore(rep),
 			byIPHash(sha256.New()),
 		)
 		if len(sample) == 0 {

--- a/network/dialer.go
+++ b/network/dialer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func handleDialing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager, pending pendingManager, addresses addressManager, rep reputationManager, handlers handlerManager, stop <-chan struct{}) {
+func handleDialing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager, pending pendingManager, book addressManager, rep reputationManager, handlers handlerManager, stop <-chan struct{}) {
 	defer wg.Done()
 
 	// extract needed configuration parameters
@@ -59,10 +59,11 @@ func handleDialing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers pe
 		if peerCount+pendingCount >= maxPeers {
 			continue
 		}
-		sample := addresses.Sample(1,
+		sample := book.Sample(1,
 			isNot([]string{address}),
 			isNot(pending.Addresses()),
 			isNot(peers.Addresses()),
+			isAbove(rep, -5),
 			byReputation(rep),
 			byIPHash(sha256.New()),
 		)

--- a/network/dialer.go
+++ b/network/dialer.go
@@ -33,7 +33,6 @@ func handleDialing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers pe
 		address  = cfg.address
 		interval = cfg.interval
 		minPeers = cfg.minPeers
-		maxPeers = cfg.maxPeers
 	)
 
 	// configure logger and add start/stop messages
@@ -52,11 +51,7 @@ func handleDialing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers pe
 		case <-ticker.C:
 		}
 		peerCount := peers.Count()
-		pendingCount := pending.Count()
 		if peerCount >= minPeers {
-			continue
-		}
-		if peerCount+pendingCount >= maxPeers {
 			continue
 		}
 		sample := book.Sample(1,

--- a/network/dialer_test.go
+++ b/network/dialer_test.go
@@ -44,7 +44,7 @@ func (suite *DialerSuite) SetupTest() {
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
 	suite.cfg = Config{
-		interval: time.Millisecond,
+		interval: 2 * time.Millisecond,
 		minPeers: 5,
 	}
 }

--- a/network/dialer_test.go
+++ b/network/dialer_test.go
@@ -117,7 +117,7 @@ func (suite *DialerSuite) TestDialerNoAddresses() {
 
 	handlers.AssertCalled(t, "Discoverer")
 
-	handlers.AssertNotCalled(t, "Connector")
+	handlers.AssertNotCalled(t, "Connector", mock.Anything)
 }
 
 func (suite *DialerSuite) TestDialerEnoughPeers() {
@@ -151,6 +151,6 @@ func (suite *DialerSuite) TestDialerEnoughPeers() {
 	// assert
 	t := suite.T()
 
-	handlers.AssertNotCalled(t, "Connector")
+	handlers.AssertNotCalled(t, "Connector", mock.Anything)
 	handlers.AssertNotCalled(t, "Discoverer")
 }

--- a/network/dialer_test.go
+++ b/network/dialer_test.go
@@ -44,9 +44,8 @@ func (suite *DialerSuite) SetupTest() {
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
 	suite.cfg = Config{
-		interval: 10 * time.Millisecond,
+		interval: time.Millisecond,
 		minPeers: 5,
-		maxPeers: 15,
 	}
 }
 
@@ -57,38 +56,33 @@ func (suite *DialerSuite) TestDialerSuccess() {
 	stop := make(chan struct{})
 
 	peers := &PeerManagerMock{}
-	peers.On("Count").Return(3)
+	peers.On("Count").Return(4)
 	peers.On("Addresses").Return([]string{})
 
 	pending := &PendingManagerMock{}
-	pending.On("Count").Return(5)
 	pending.On("Addresses").Return([]string{})
 
 	rep := &ReputationManagerMock{}
 
 	addresses := &AddressManagerMock{}
-	addresses.On("Sample", 1, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{address})
+	addresses.On("Sample", mock.Anything, mock.Anything).Return([]string{address})
 
 	handlers := &HandlerManagerMock{}
-	handlers.On("Connector", address)
+	handlers.On("Connector", mock.Anything)
 	handlers.On("Discoverer")
 
 	// act
 	go handleDialing(suite.log, &suite.wg, &suite.cfg, peers, pending, addresses, rep, handlers, stop)
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(time.Duration(1.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 
 	// assert
-	addresses.AssertCalled(suite.T(), "Sample", 1,
-		mock.AnythingOfType("func(string) bool"),
-		mock.AnythingOfType("func(string) bool"),
-		mock.AnythingOfType("func(string) bool"),
-		mock.AnythingOfType("func(string, string) bool"),
-		mock.AnythingOfType("func(string, string) bool"),
-	)
-	handlers.AssertCalled(suite.T(), "Connector", address)
-	handlers.AssertNotCalled(suite.T(), "Discoverer")
+	t := suite.T()
+
+	handlers.AssertCalled(t, "Connector", address)
+
+	handlers.AssertNotCalled(t, "Discoverer")
 }
 
 func (suite *DialerSuite) TestDialerNoAddresses() {
@@ -97,17 +91,16 @@ func (suite *DialerSuite) TestDialerNoAddresses() {
 	stop := make(chan struct{})
 
 	peers := &PeerManagerMock{}
-	peers.On("Count").Return(3)
+	peers.On("Count").Return(4)
 	peers.On("Addresses").Return([]string{})
 
 	pending := &PendingManagerMock{}
-	pending.On("Count").Return(5)
 	pending.On("Addresses").Return([]string{})
 
 	rep := &ReputationManagerMock{}
 
 	addresses := &AddressManagerMock{}
-	addresses.On("Sample", 1, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{})
+	addresses.On("Sample", mock.Anything, mock.Anything).Return([]string{})
 
 	handlers := &HandlerManagerMock{}
 	handlers.On("Connector", mock.Anything)
@@ -115,36 +108,35 @@ func (suite *DialerSuite) TestDialerNoAddresses() {
 
 	// act
 	go handleDialing(suite.log, &suite.wg, &suite.cfg, peers, pending, addresses, rep, handlers, stop)
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(time.Duration(1.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 
 	// assert
-	addresses.AssertCalled(suite.T(), "Sample", 1,
-		mock.AnythingOfType("func(string) bool"),
-		mock.AnythingOfType("func(string) bool"),
-		mock.AnythingOfType("func(string) bool"),
-		mock.AnythingOfType("func(string, string) bool"),
-		mock.AnythingOfType("func(string, string) bool"),
-	)
-	handlers.AssertNotCalled(suite.T(), "Connector")
-	handlers.AssertCalled(suite.T(), "Discoverer")
+	t := suite.T()
+
+	handlers.AssertCalled(t, "Discoverer")
+
+	handlers.AssertNotCalled(t, "Connector")
 }
 
 func (suite *DialerSuite) TestDialerEnoughPeers() {
 
 	// arrange
+	address := "192.0.2.101:1337"
 	stop := make(chan struct{})
 
 	peers := &PeerManagerMock{}
 	peers.On("Count").Return(5)
+	peers.On("Addresses").Return([]string{})
 
 	pending := &PendingManagerMock{}
-	pending.On("Count").Return(3)
-
-	addresses := &AddressManagerMock{}
+	pending.On("Addresses").Return([]string{})
 
 	rep := &ReputationManagerMock{}
+
+	addresses := &AddressManagerMock{}
+	addresses.On("Sample", mock.Anything, mock.Anything).Return([]string{address})
 
 	handlers := &HandlerManagerMock{}
 	handlers.On("Connector", mock.Anything)
@@ -152,43 +144,13 @@ func (suite *DialerSuite) TestDialerEnoughPeers() {
 
 	// act
 	go handleDialing(suite.log, &suite.wg, &suite.cfg, peers, pending, addresses, rep, handlers, stop)
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(time.Duration(1.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 
 	// assert
-	addresses.AssertNotCalled(suite.T(), "Sample")
-	handlers.AssertNotCalled(suite.T(), "Connector")
-	handlers.AssertNotCalled(suite.T(), "Discoverer")
-}
+	t := suite.T()
 
-func (suite *DialerSuite) TestDialerMaximumPendingPeers() {
-
-	// arrange
-	stop := make(chan struct{})
-
-	peers := &PeerManagerMock{}
-	peers.On("Count").Return(3)
-
-	pending := &PendingManagerMock{}
-	pending.On("Count").Return(12)
-
-	addresses := &AddressManagerMock{}
-
-	rep := &ReputationManagerMock{}
-
-	handlers := &HandlerManagerMock{}
-	handlers.On("Connector", mock.Anything)
-	handlers.On("Discoverer")
-
-	// act
-	go handleDialing(suite.log, &suite.wg, &suite.cfg, peers, pending, addresses, rep, handlers, stop)
-	time.Sleep(15 * time.Millisecond)
-	close(stop)
-	suite.wg.Wait()
-
-	// assert
-	addresses.AssertNotCalled(suite.T(), "Sample")
-	handlers.AssertNotCalled(suite.T(), "Connector")
-	handlers.AssertNotCalled(suite.T(), "Discoverer")
+	handlers.AssertNotCalled(t, "Connector")
+	handlers.AssertNotCalled(t, "Discoverer")
 }

--- a/network/discoverer.go
+++ b/network/discoverer.go
@@ -41,11 +41,10 @@ func handleDiscovering(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peer
 	// get output for each peer and send the discover message
 	msg := &Discover{}
 	for _, address := range addresses {
-		output, err := peers.Output(address)
+		err := peers.Send(address, msg)
 		if err != nil {
 			log.Error().Err(err).Str("address", address).Msg("could not send discovery message")
 			continue
 		}
-		output <- msg
 	}
 }

--- a/network/dropper_test.go
+++ b/network/dropper_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -67,7 +68,9 @@ func (suite *DropperSuite) TestDropperSuccess() {
 	suite.wg.Wait()
 
 	// assert
-	peers.AssertCalled(suite.T(), "Drop", address)
+	t := suite.T()
+
+	peers.AssertCalled(t, "Drop", address)
 }
 
 func (suite *DropperSuite) TestDropperValidPeerNumber() {
@@ -88,7 +91,9 @@ func (suite *DropperSuite) TestDropperValidPeerNumber() {
 	suite.wg.Wait()
 
 	// assert
-	peers.AssertNotCalled(suite.T(), "Drop")
+	t := suite.T()
+
+	peers.AssertNotCalled(t, "Drop", mock.Anything)
 }
 
 func (suite *DropperSuite) TestDropperDropFails() {
@@ -109,6 +114,8 @@ func (suite *DropperSuite) TestDropperDropFails() {
 	suite.wg.Wait()
 
 	// assert
-	peers.AssertCalled(suite.T(), "Drop", address)
-	peers.AssertNumberOfCalls(suite.T(), "Drop", 2)
+	t := suite.T()
+
+	peers.AssertCalled(t, "Drop", address)
+	peers.AssertNumberOfCalls(t, "Drop", 2)
 }

--- a/network/dropper_test.go
+++ b/network/dropper_test.go
@@ -45,7 +45,7 @@ func (suite *DropperSuite) SetupTest() {
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
 	suite.cfg = Config{
-		interval: 10 * time.Millisecond,
+		interval: 2 * time.Millisecond,
 		maxPeers: 15,
 	}
 }
@@ -63,7 +63,7 @@ func (suite *DropperSuite) TestDropperSuccess() {
 
 	// act
 	go handleDropping(suite.log, &suite.wg, &suite.cfg, peers, stop)
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(time.Duration(1.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 
@@ -86,7 +86,7 @@ func (suite *DropperSuite) TestDropperValidPeerNumber() {
 
 	// act
 	go handleDropping(suite.log, &suite.wg, &suite.cfg, peers, stop)
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(time.Duration(1.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 
@@ -109,7 +109,7 @@ func (suite *DropperSuite) TestDropperDropFails() {
 
 	// act
 	go handleDropping(suite.log, &suite.wg, &suite.cfg, peers, stop)
-	time.Sleep(25 * time.Millisecond)
+	time.Sleep(time.Duration(2.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 

--- a/network/filters.go
+++ b/network/filters.go
@@ -27,3 +27,9 @@ func isNot(addresses []string) func(string) bool {
 		return !ok
 	}
 }
+
+func isAbove(rep reputationManager, threshold float32) func(string) bool {
+	return func(address string) bool {
+		return rep.Score(address) > threshold
+	}
+}

--- a/network/filters.go
+++ b/network/filters.go
@@ -17,6 +17,8 @@
 
 package network
 
+import "time"
+
 func isNot(addresses []string) func(string) bool {
 	lookup := make(map[string]struct{})
 	for _, address := range addresses {
@@ -28,8 +30,14 @@ func isNot(addresses []string) func(string) bool {
 	}
 }
 
-func isAbove(rep reputationManager, threshold float32) func(string) bool {
+func isScoreAbove(rep reputationManager, threshold float32) func(string) bool {
 	return func(address string) bool {
 		return rep.Score(address) > threshold
+	}
+}
+
+func isLastBefore(rep reputationManager, cutoff time.Time) func(string) bool {
+	return func(address string) bool {
+		return rep.Last(address).Before(cutoff)
 	}
 }

--- a/network/filters_test.go
+++ b/network/filters_test.go
@@ -19,6 +19,7 @@ package network
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -58,5 +59,70 @@ func TestIsNot(t *testing.T) {
 	for name, vector := range vectors {
 		actual := vector.filter(vector.entry)
 		assert.Equalf(t, vector.expected, actual, "Is not filter wrong result for %v", name)
+	}
+}
+
+func TestIsScoreAbove(t *testing.T) {
+
+	address := "192.0.1.100:1337"
+
+	rep := &ReputationManagerMock{}
+	rep.On("Score", address).Return(float64(10))
+
+	vectors := map[string]struct {
+		threshold float32
+		expected  bool
+	}{
+		"above": {
+			threshold: 9,
+			expected:  true,
+		},
+		"equal": {
+			threshold: 10,
+			expected:  false,
+		},
+		"below": {
+			threshold: 11,
+			expected:  false,
+		},
+	}
+
+	for name, vector := range vectors {
+		filter := isScoreAbove(rep, vector.threshold)
+		actual := filter(address)
+		assert.Equalf(t, vector.expected, actual, "Is score above wrong result for %v", name)
+	}
+}
+
+func TestIsLastBefore(t *testing.T) {
+
+	address := "192.0.1.100:1337"
+	now := time.Now()
+
+	rep := &ReputationManagerMock{}
+	rep.On("Last", address).Return(now)
+
+	vectors := map[string]struct {
+		cutoff   time.Time
+		expected bool
+	}{
+		"before": {
+			cutoff:   now.Add(time.Second),
+			expected: true,
+		},
+		"equal": {
+			cutoff:   now,
+			expected: false,
+		},
+		"after": {
+			cutoff:   now.Add(-time.Second),
+			expected: false,
+		},
+	}
+
+	for name, vector := range vectors {
+		filter := isLastBefore(rep, vector.cutoff)
+		actual := filter(address)
+		assert.Equalf(t, vector.expected, actual, "Is score above wrong result for %v", name)
 	}
 }

--- a/network/listener_test.go
+++ b/network/listener_test.go
@@ -70,7 +70,9 @@ func (suite *ListenerSuite) TestListenerSuccess() {
 	suite.wg.Wait()
 
 	// assert
-	handlers.AssertCalled(suite.T(), "Acceptor", conn)
+	t := suite.T()
+
+	handlers.AssertCalled(t, "Acceptor", conn)
 }
 
 func (suite *ListenerSuite) TestListenerListeningFails() {
@@ -82,16 +84,20 @@ func (suite *ListenerSuite) TestListenerListeningFails() {
 	listener.On("Listen", suite.cfg.address).Return(ln, errors.New("could not listen"))
 
 	handlers := &HandlerManagerMock{}
+	handlers.On("Acceptor", mock.Anything)
 
 	// act
 	go handleListening(suite.log, &suite.wg, &suite.cfg, handlers, listener, nil)
 	suite.wg.Wait()
 
 	// assert
-	listener.AssertCalled(suite.T(), "Listen", suite.cfg.address)
-	ln.AssertNotCalled(suite.T(), "Accept")
-	ln.AssertNotCalled(suite.T(), "Close")
-	handlers.AssertNotCalled(suite.T(), "Acceptor")
+	t := suite.T()
+
+	listener.AssertCalled(t, "Listen", suite.cfg.address)
+
+	ln.AssertNotCalled(t, "Accept")
+	ln.AssertNotCalled(t, "Close")
+	handlers.AssertNotCalled(t, "Acceptor", mock.Anything)
 }
 
 func (suite *ListenerSuite) TestListenerAcceptFails() {
@@ -112,7 +118,9 @@ func (suite *ListenerSuite) TestListenerAcceptFails() {
 	suite.wg.Wait()
 
 	// assert
-	handlers.AssertNotCalled(suite.T(), "Acceptor")
+	t := suite.T()
+
+	handlers.AssertNotCalled(t, "Acceptor", mock.Anything)
 }
 
 func (suite *ListenerSuite) TestListenerShutdown() {
@@ -134,7 +142,9 @@ func (suite *ListenerSuite) TestListenerShutdown() {
 	suite.wg.Wait()
 
 	// assert
-	ln.AssertCalled(suite.T(), "Close")
+	t := suite.T()
+
+	ln.AssertCalled(t, "Close")
 }
 
 func (suite *ListenerSuite) TestListenerTimeout() {
@@ -164,8 +174,10 @@ func (suite *ListenerSuite) TestListenerTimeout() {
 	suite.wg.Wait()
 
 	// assert
-	ln.AssertCalled(suite.T(), "Accept")
-	handlers.AssertCalled(suite.T(), "Acceptor", conn)
+	t := suite.T()
+
+	ln.AssertCalled(t, "Accept")
+	handlers.AssertCalled(t, "Acceptor", conn)
 }
 
 func (suite *ListenerSuite) TestListenerCloseFails() {
@@ -190,5 +202,7 @@ func (suite *ListenerSuite) TestListenerCloseFails() {
 	suite.wg.Wait()
 
 	// assert
-	ln.AssertCalled(suite.T(), "Close")
+	t := suite.T()
+
+	ln.AssertCalled(t, "Close")
 }

--- a/network/mocks_test.go
+++ b/network/mocks_test.go
@@ -202,13 +202,9 @@ func (pm *PeerManagerMock) Add(conn net.Conn, nonce []byte) error {
 	return args.Error(0)
 }
 
-func (pm *PeerManagerMock) Output(address string) (chan<- interface{}, error) {
-	args := pm.Called(address)
-	var output chan interface{}
-	if args.Get(0) != nil {
-		output = args.Get(0).(chan interface{})
-	}
-	return output, args.Error(1)
+func (pm *PeerManagerMock) Send(address string, msg interface{}) error {
+	args := pm.Called(address, msg)
+	return args.Error(0)
 }
 
 func (pm *PeerManagerMock) Drop(address string) error {

--- a/network/mocks_test.go
+++ b/network/mocks_test.go
@@ -329,8 +329,7 @@ func (am *AddressManagerMock) Unpin(address string) {
 }
 
 func (am *AddressManagerMock) Sample(count uint, params ...interface{}) []string {
-	params = append([]interface{}{int(count)}, params...)
-	args := am.Called(params...)
+	args := am.Called(count, params)
 	var sample []string
 	if args.Get(0) != nil {
 		sample = args.Get(0).([]string)

--- a/network/mocks_test.go
+++ b/network/mocks_test.go
@@ -235,15 +235,7 @@ type ReputationManagerMock struct {
 	mock.Mock
 }
 
-func (rm *ReputationManagerMock) Error(address string) {
-	_ = rm.Called(address)
-}
-
 func (rm *ReputationManagerMock) Failure(address string) {
-	_ = rm.Called(address)
-}
-
-func (rm *ReputationManagerMock) Invalid(address string) {
 	_ = rm.Called(address)
 }
 
@@ -254,6 +246,11 @@ func (rm *ReputationManagerMock) Success(address string) {
 func (rm *ReputationManagerMock) Score(address string) float32 {
 	args := rm.Called(address)
 	return float32(args.Get(0).(float64))
+}
+
+func (rm *ReputationManagerMock) Last(address string) time.Time {
+	args := rm.Called(address)
+	return args.Get(0).(time.Time)
 }
 
 type HandlerManagerMock struct {

--- a/network/network.go
+++ b/network/network.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	uuid "github.com/satori/go.uuid"
 )
@@ -53,7 +52,7 @@ type simpleNetwork struct {
 	cfg        *Config
 	dialer     dialWrapper
 	listener   listenWrapper
-	addresses  addressManager
+	book       addressManager
 	pending    pendingManager
 	peers      peerManager
 	rep        reputationManager
@@ -94,9 +93,9 @@ func New(log zerolog.Logger, codec Codec, options ...func(*Config)) Network {
 	net.cfg = cfg
 
 	// initialize the address manager that handles outgoing addresses
-	addresses := newSimpleAddressManager()
-	addresses.Block(cfg.address)
-	net.addresses = addresses
+	book := newSimpleAddressManager()
+	book.Block(cfg.address)
+	net.book = book
 
 	// initialize the slots manager that handles connection slots
 	pending := newSimplePendingManager(cfg.maxPending)
@@ -118,6 +117,14 @@ func New(log zerolog.Logger, codec Codec, options ...func(*Config)) Network {
 	stop := make(chan struct{})
 	net.stop = stop
 
+	// initialize the listen function wrapper
+	listener := &simpleListenWrapper{}
+	net.listener = listener
+
+	// initialize the dial function wrapper
+	dialer := &simpleDialWrapper{}
+	net.dialer = dialer
+
 	// initialize the initial handlers
 	net.Dropper()
 	net.Server()
@@ -127,47 +134,57 @@ func New(log zerolog.Logger, codec Codec, options ...func(*Config)) Network {
 }
 
 func (net *simpleNetwork) Dropper() {
+	net.wg.Add(1)
 	go handleDropping(net.log, net.wg, net.cfg, net.peers, net.stop)
 }
 
 func (net *simpleNetwork) Server() {
+	net.wg.Add(1)
 	go handleServing(net.log, net.wg, net.cfg, net.peers, net, net.stop)
 }
 
 func (net *simpleNetwork) Dialer() {
-	go handleDialing(net.log, net.wg, net.cfg, net.peers, net.pending, net.addresses, net.rep, net, net.stop)
+	net.wg.Add(1)
+	go handleDialing(net.log, net.wg, net.cfg, net.peers, net.pending, net.book, net.rep, net, net.stop)
 }
 
 func (net *simpleNetwork) Listener() {
+	net.wg.Add(1)
 	go handleListening(net.log, net.wg, net.cfg, net, net.listener, net.stop)
 }
 
 func (net *simpleNetwork) Discoverer() {
+	net.wg.Add(1)
 	go handleDiscovering(net.log, net.wg, net.cfg, net.peers)
 }
 
 func (net *simpleNetwork) Acceptor(conn net.Conn) {
-	go handleAccepting(net.log, net.wg, net.cfg, net.pending, net.peers, net.rep, conn)
+	net.wg.Add(1)
+	go handleAccepting(net.log, net.wg, net.cfg, net.pending, net.peers, net.rep, net.book, conn)
 }
 
 func (net *simpleNetwork) Connector(address string) {
-	go handleConnecting(net.log, net.wg, net.cfg, net.pending, net.peers, net.rep, net.dialer, address)
+	net.wg.Add(1)
+	go handleConnecting(net.log, net.wg, net.cfg, net.pending, net.peers, net.rep, net.book, net.dialer, address)
 }
 
 func (net *simpleNetwork) Sender(address string, output <-chan interface{}, w io.Writer) {
+	net.wg.Add(1)
 	go handleSending(net.log, net.wg, net.cfg, net.peers, net.rep, address, output, w)
 }
 
 func (net *simpleNetwork) Processor(address string, input <-chan interface{}, output chan<- interface{}) {
-	go handleProcessing(net.log, net.wg, net.cfg, net.addresses, net.peers, net.subscriber, address, input, output)
+	net.wg.Add(1)
+	go handleProcessing(net.log, net.wg, net.cfg, net.book, net.peers, net.subscriber, address, input, output)
 }
 
 func (net *simpleNetwork) Receiver(address string, r io.Reader, input chan<- interface{}) {
+	net.wg.Add(1)
 	go handleReceiving(net.log, net.wg, net.cfg, net.peers, net.rep, address, r, input)
 }
 
 func (net *simpleNetwork) Add(address string) {
-	net.addresses.Add(address)
+	net.book.Add(address)
 }
 
 func (net *simpleNetwork) Stop() {
@@ -185,7 +202,7 @@ func (net *simpleNetwork) Subscribe() <-chan interface{} {
 }
 
 // Broadcast broadcasts a message to all peers.
-func (net *simpleNetwork) Broadcast(i interface{}, exclude ...string) {
+func (net *simpleNetwork) Broadcast(msg interface{}, exclude ...string) {
 	addresses := net.peers.Addresses()
 	lookup := make(map[string]struct{})
 	for _, address := range exclude {
@@ -196,21 +213,15 @@ func (net *simpleNetwork) Broadcast(i interface{}, exclude ...string) {
 		if ok {
 			continue
 		}
-		output, err := net.peers.Output(address)
+		err := net.peers.Send(address, msg)
 		if err != nil {
 			net.log.Error().Err(err).Str("address", address).Msg("could not broadcast to peer")
 			continue
 		}
-		output <- i
 	}
 }
 
 // Send sends a message to the peer with the given address.
-func (net *simpleNetwork) Send(address string, i interface{}) error {
-	output, err := net.peers.Output(address)
-	if err != nil {
-		return errors.Wrap(err, "could not send to peer")
-	}
-	output <- i
-	return nil
+func (net *simpleNetwork) Send(address string, msg interface{}) error {
+	return net.peers.Send(address, msg)
 }

--- a/network/network.go
+++ b/network/network.go
@@ -83,7 +83,7 @@ func New(log zerolog.Logger, codec Codec, options ...func(*Config)) Network {
 		maxPeers:   10,
 		maxPending: 16,
 		nonce:      uuid.NewV4().Bytes(),
-		interval:   time.Second * 1,
+		interval:   time.Second,
 		codec:      codec,
 		bufferSize: 16,
 	}
@@ -170,7 +170,7 @@ func (net *simpleNetwork) Connector(address string) {
 
 func (net *simpleNetwork) Sender(address string, output <-chan interface{}, w io.Writer) {
 	net.wg.Add(1)
-	go handleSending(net.log, net.wg, net.cfg, net.peers, net.rep, address, output, w)
+	go handleSending(net.log, net.wg, net.cfg, net.rep, address, output, w)
 }
 
 func (net *simpleNetwork) Processor(address string, input <-chan interface{}, output chan<- interface{}) {
@@ -180,7 +180,7 @@ func (net *simpleNetwork) Processor(address string, input <-chan interface{}, ou
 
 func (net *simpleNetwork) Receiver(address string, r io.Reader, input chan<- interface{}) {
 	net.wg.Add(1)
-	go handleReceiving(net.log, net.wg, net.cfg, net.peers, net.rep, address, r, input)
+	go handleReceiving(net.log, net.wg, net.cfg, net.rep, address, r, input)
 }
 
 func (net *simpleNetwork) Add(address string) {

--- a/network/peerManager.go
+++ b/network/peerManager.go
@@ -113,11 +113,11 @@ func (pm *simplePeerManager) Drop(address string) error {
 	if !ok {
 		return errors.New("peer unknown")
 	}
+	delete(pm.reg, address)
 	err := p.conn.Close()
 	if err != nil {
 		return errors.Wrap(err, "could not close peer connection")
 	}
-	delete(pm.reg, address)
 	return nil
 }
 

--- a/network/peerManager_test.go
+++ b/network/peerManager_test.go
@@ -139,16 +139,17 @@ func TestPeerManagerAddresses(t *testing.T) {
 	assert.ElementsMatch(t, []string{address1, address2}, addresses)
 }
 
-func TestPeerManagerOutput(t *testing.T) {
-	peers := &simplePeerManager{reg: make(map[string]*peer)}
-
-	address := "192.0.2.100:1337"
-	_, err := peers.Output(address)
-	assert.NotNil(t, err)
-
-	p := &peer{output: make(chan interface{})}
-	peers.reg[address] = p
-	output, err := peers.Output(address)
-	assert.Nil(t, err)
-	assert.Equal(t, output, (chan<- interface{})(p.output))
+func TestPeerManagerSend(t *testing.T) {
+	// TODO
+	// peers := &simplePeerManager{reg: make(map[string]*peer)}
+	//
+	// address := "192.0.2.100:1337"
+	// err := peers.Output(address, msg)
+	// assert.NotNil(t, err)
+	//
+	// p := &peer{output: make(chan interface{})}
+	// peers.reg[address] = p
+	// err := peers.Output(address, msg)
+	// assert.Nil(t, err)
+	// assert.Equal(t, output, (chan<- interface{})(p.output))
 }

--- a/network/peerManager_test.go
+++ b/network/peerManager_test.go
@@ -141,16 +141,28 @@ func TestPeerManagerAddresses(t *testing.T) {
 }
 
 func TestPeerManagerSend(t *testing.T) {
-	// TODO
-	// peers := &simplePeerManager{reg: make(map[string]*peer)}
-	//
-	// address := "192.0.2.100:1337"
-	// err := peers.Output(address, msg)
-	// assert.NotNil(t, err)
-	//
-	// p := &peer{output: make(chan interface{})}
-	// peers.reg[address] = p
-	// err := peers.Output(address, msg)
-	// assert.Nil(t, err)
-	// assert.Equal(t, output, (chan<- interface{})(p.output))
+
+	msg := "message"
+	address := "192.0.2.100:1337"
+
+	peers := &simplePeerManager{reg: make(map[string]*peer)}
+
+	err := peers.Send(address, msg)
+	assert.NotNil(t, err)
+
+	output := make(chan interface{}, 1)
+	p := &peer{output: output}
+	peers.reg[address] = p
+	err = peers.Send(address, msg)
+	assert.Nil(t, err)
+	select {
+	case received := <-output:
+		assert.Equal(t, msg, received)
+	default:
+		t.Error("no message in output channel")
+	}
+
+	peers.reg[address].output = nil
+	err = peers.Send(address, msg)
+	assert.NotNil(t, err)
 }

--- a/network/peerManager_test.go
+++ b/network/peerManager_test.go
@@ -90,9 +90,10 @@ func TestPeerManagerDrop(t *testing.T) {
 	peers.reg[address] = p
 	err = peers.Drop(address)
 	assert.NotNil(t, err)
-	assert.Contains(t, peers.reg, address)
+	assert.Empty(t, peers.reg)
 
 	conn.On("Close").Return(nil)
+	peers.reg[address] = p
 	err = peers.Drop(address)
 	assert.Nil(t, err)
 	assert.Empty(t, peers.reg)

--- a/network/processor.go
+++ b/network/processor.go
@@ -24,7 +24,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func handleProcessing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, addresses addressManager, peers peerManager, subscriber chan<- interface{}, address string, input <-chan interface{}, output chan<- interface{}) {
+func handleProcessing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, book addressManager, peers peerManager, subscriber chan<- interface{}, address string, input <-chan interface{}, output chan<- interface{}) {
 	defer wg.Done()
 
 	// configuration parameters
@@ -62,12 +62,12 @@ Loop:
 				log.Debug().Msg("pong received")
 			case *Discover:
 				log.Debug().Msg("discover received")
-				sample := addresses.Sample(8)
+				sample := book.Sample(8)
 				output <- &Peers{Addresses: sample}
 			case *Peers:
 				log.Debug().Msg("peer received")
 				for _, address := range msg.Addresses {
-					addresses.Add(address)
+					book.Add(address)
 				}
 			default:
 				log.Debug().Msg("custom received")
@@ -81,7 +81,7 @@ Loop:
 					// success
 				default:
 					log.Debug().Msg("subscriber stalling")
-					// no subscriber of subscriber stalling
+					// no subscriber or subscriber stalling
 				}
 			}
 		case <-time.After(interval):

--- a/network/processor.go
+++ b/network/processor.go
@@ -83,9 +83,15 @@ Loop:
 			log.Debug().Msg("sending heartbeat")
 			output <- &Ping{}
 		case <-timeout.C:
-			log.Info().Msg("peer timed out, dropping")
-			peers.Drop(address)
+			log.Info().Msg("peer timed out")
+			err := peers.Drop(address)
+			if err != nil {
+				log.Error().Err(err).Msg("could not drop peer")
+			}
+			break Loop
 		}
+	}
+	for _ = range input {
 	}
 	close(output)
 }

--- a/network/processor.go
+++ b/network/processor.go
@@ -30,8 +30,6 @@ func handleProcessing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, book 
 	// configuration parameters
 	var (
 		interval = cfg.interval
-		listen   = cfg.listen
-		laddress = cfg.address
 	)
 
 	// configure logger and add start/stop messages
@@ -41,9 +39,6 @@ func handleProcessing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, book 
 
 	// for each message, handle it as adequate
 	timeout := time.NewTimer(time.Duration(3.5 * float64(interval)))
-	if listen {
-		output <- &Peers{Addresses: []string{laddress}}
-	}
 	output <- &Discover{}
 Loop:
 	for {

--- a/network/processor_test.go
+++ b/network/processor_test.go
@@ -138,17 +138,18 @@ func (suite *ProcessorSuite) TestProcessorTimeout() {
 
 	// act
 	go handleProcessing(suite.log, &suite.wg, &suite.cfg, book, peers, subscriber, address, input, output)
-	time.Sleep(time.Duration(4 * float64(suite.cfg.interval)))
+	time.Sleep(time.Duration(4.5 * float64(suite.cfg.interval)))
 	close(input)
+	count := 0
 	for _ = range output {
-		// just drain
+		count++
 	}
 	suite.wg.Wait()
 
 	// assert
 	t := suite.T()
 
-	peers.AssertCalled(t, "Drop", address)
+	assert.Equal(t, 4, count)
 }
 
 func (suite *ProcessorSuite) TestProcessorUnknownMessage() {

--- a/network/processor_test.go
+++ b/network/processor_test.go
@@ -46,7 +46,7 @@ func (suite *ProcessorSuite) SetupTest() {
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
 	suite.cfg = Config{
-		interval: time.Millisecond,
+		interval: 2 * time.Millisecond,
 	}
 }
 

--- a/network/receiver.go
+++ b/network/receiver.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func handleReceiving(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager, rep reputationManager, address string, r io.Reader, input chan<- interface{}) {
+func handleReceiving(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, rep reputationManager, address string, r io.Reader, input chan<- interface{}) {
 	defer wg.Done()
 
 	// extract configuration as needed
@@ -43,10 +43,6 @@ func handleReceiving(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers 
 		msg, err := codec.Decode(r)
 		if errors.Cause(err) == io.EOF || isClosedErr(err) {
 			log.Info().Msg("network connection closed")
-			err = peers.Drop(address)
-			if err != nil {
-				log.Error().Err(err).Msg("could not drop peer")
-			}
 			break
 		}
 		if err != nil {

--- a/network/receiver.go
+++ b/network/receiver.go
@@ -43,15 +43,15 @@ func handleReceiving(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers 
 		msg, err := codec.Decode(r)
 		if errors.Cause(err) == io.EOF || isClosedErr(err) {
 			log.Info().Msg("network connection closed")
-			break
-		}
-		if err != nil {
-			log.Error().Err(err).Msg("could not read message")
-			rep.Error(address)
 			err = peers.Drop(address)
 			if err != nil {
 				log.Error().Err(err).Msg("could not drop peer")
 			}
+			break
+		}
+		if err != nil {
+			log.Error().Err(err).Msg("could not read message")
+			rep.Failure(address)
 			continue
 		}
 		input <- msg

--- a/network/receiver_test.go
+++ b/network/receiver_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -48,64 +49,15 @@ func (suite *ReceiverSuite) SetupTest() {
 	suite.cfg = Config{}
 }
 
-func (suite *ReceiverSuite) TestReceiverEOFError() {
+func (suite *ReceiverSuite) TestReceiverSuccess() {
 
 	// arrange
 	address := "192.0.2.100:1337"
 	input := make(chan interface{}, 16)
 	r := &bytes.Buffer{}
 
-	peers := &PeerManagerMock{}
-
 	rep := &ReputationManagerMock{}
-
-	codec := &CodecMock{}
-	codec.On("Decode", r).Return(nil, io.EOF)
-
-	// act
-	suite.cfg.codec = codec
-	go handleReceiving(suite.log, &suite.wg, &suite.cfg, peers, rep, address, r, input)
-	suite.wg.Wait()
-
-	// assert
-	_, ok := <-input
-	assert.False(suite.T(), ok)
-}
-
-func (suite *ReceiverSuite) TestReceiverClosedError() {
-
-	// arrange
-	address := "192.0.2.100:1337"
-	input := make(chan interface{}, 16)
-	r := &bytes.Buffer{}
-
-	peers := &PeerManagerMock{}
-
-	rep := &ReputationManagerMock{}
-
-	codec := &CodecMock{}
-	codec.On("Decode", r).Return(nil, errors.New("use of closed network connection"))
-
-	// act
-	suite.cfg.codec = codec
-	go handleReceiving(suite.log, &suite.wg, &suite.cfg, peers, rep, address, r, input)
-	suite.wg.Wait()
-
-	// assert
-	_, ok := <-input
-	assert.False(suite.T(), ok)
-}
-
-func (suite *ReceiverSuite) TestReceiverReceiveMessages() {
-
-	// arrange
-	address := "192.0.2.100:1337"
-	input := make(chan interface{}, 16)
-	r := &bytes.Buffer{}
-
-	peers := &PeerManagerMock{}
-
-	rep := &ReputationManagerMock{}
+	rep.On("Failure", mock.Anything)
 
 	codec := &CodecMock{}
 	codec.On("Decode", r).Return(&Ping{}, nil).Once()
@@ -116,7 +68,7 @@ func (suite *ReceiverSuite) TestReceiverReceiveMessages() {
 
 	// act
 	suite.cfg.codec = codec
-	go handleReceiving(suite.log, &suite.wg, &suite.cfg, peers, rep, address, r, input)
+	go handleReceiving(suite.log, &suite.wg, &suite.cfg, rep, address, r, input)
 	var msgs []interface{}
 	for msg := range input {
 		msgs = append(msgs, msg)
@@ -124,27 +76,56 @@ func (suite *ReceiverSuite) TestReceiverReceiveMessages() {
 	suite.wg.Wait()
 
 	// assert
-	if assert.Len(suite.T(), msgs, 4) {
-		assert.IsType(suite.T(), &Ping{}, msgs[0])
-		assert.IsType(suite.T(), &Pong{}, msgs[1])
-		assert.IsType(suite.T(), &Discover{}, msgs[2])
-		assert.IsType(suite.T(), &Peers{}, msgs[3])
+	t := suite.T()
+
+	if assert.Len(t, msgs, 4) {
+		assert.IsType(t, &Ping{}, msgs[0])
+		assert.IsType(t, &Pong{}, msgs[1])
+		assert.IsType(t, &Discover{}, msgs[2])
+		assert.IsType(t, &Peers{}, msgs[3])
 	}
+
+	rep.AssertNotCalled(t, "Failure")
 }
 
-func (suite *ReceiverSuite) TestReceiverDecodeFails() {
+func (suite *ReceiverSuite) TestReceiverEOF() {
 
 	// arrange
 	address := "192.0.2.100:1337"
-	message := "some message"
 	input := make(chan interface{}, 16)
 	r := &bytes.Buffer{}
 
-	peers := &PeerManagerMock{}
-	peers.On("Drop", address).Return(errors.New("dropping failed"))
+	rep := &ReputationManagerMock{}
+	rep.On("Failure", mock.Anything)
+
+	codec := &CodecMock{}
+	codec.On("Decode", r).Return(nil, io.EOF)
+
+	// act
+	suite.cfg.codec = codec
+	go handleReceiving(suite.log, &suite.wg, &suite.cfg, rep, address, r, input)
+	suite.wg.Wait()
+
+	// assert
+	t := suite.T()
+
+	_, ok := <-input
+	assert.False(t, ok)
+
+	rep.AssertNotCalled(t, "Failure", address)
+}
+
+func (suite *ReceiverSuite) TestReceiverError() {
+
+	// arrange
+	address := "192.0.2.100:1337"
+	input := make(chan interface{}, 16)
+	r := &bytes.Buffer{}
+
+	message := "message"
 
 	rep := &ReputationManagerMock{}
-	rep.On("Error", address)
+	rep.On("Failure", mock.Anything)
 
 	codec := &CodecMock{}
 	codec.On("Decode", r).Return(nil, errors.New("could not encode message")).Once()
@@ -153,7 +134,7 @@ func (suite *ReceiverSuite) TestReceiverDecodeFails() {
 
 	// act
 	suite.cfg.codec = codec
-	go handleReceiving(suite.log, &suite.wg, &suite.cfg, peers, rep, address, r, input)
+	go handleReceiving(suite.log, &suite.wg, &suite.cfg, rep, address, r, input)
 	var msgs []interface{}
 	for msg := range input {
 		msgs = append(msgs, msg)
@@ -161,9 +142,10 @@ func (suite *ReceiverSuite) TestReceiverDecodeFails() {
 	suite.wg.Wait()
 
 	// assert
-	rep.AssertCalled(suite.T(), "Error", address)
-	peers.AssertCalled(suite.T(), "Drop", address)
-	if assert.Len(suite.T(), msgs, 1) {
-		assert.Equal(suite.T(), message, msgs[0])
+	t := suite.T()
+
+	rep.AssertCalled(t, "Failure", address)
+	if assert.Len(t, msgs, 1) {
+		assert.Equal(t, message, msgs[0])
 	}
 }

--- a/network/receiver_test.go
+++ b/network/receiver_test.go
@@ -85,7 +85,7 @@ func (suite *ReceiverSuite) TestReceiverSuccess() {
 		assert.IsType(t, &Peers{}, msgs[3])
 	}
 
-	rep.AssertNotCalled(t, "Failure")
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
 }
 
 func (suite *ReceiverSuite) TestReceiverEOF() {
@@ -112,7 +112,7 @@ func (suite *ReceiverSuite) TestReceiverEOF() {
 	_, ok := <-input
 	assert.False(t, ok)
 
-	rep.AssertNotCalled(t, "Failure", address)
+	rep.AssertNotCalled(t, "Failure", mock.Anything)
 }
 
 func (suite *ReceiverSuite) TestReceiverError() {

--- a/network/reputationManager.go
+++ b/network/reputationManager.go
@@ -17,22 +17,28 @@
 
 package network
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 type reputationManager interface {
 	Failure(address string)
 	Success(address string)
 	Score(address string) float32
+	Last(address string) time.Time
 }
 
 type simpleReputationManager struct {
 	sync.Mutex
 	scores map[string]float32
+	lasts  map[string]time.Time
 }
 
 func newSimpleReputationManager() *simpleReputationManager {
 	return &simpleReputationManager{
 		scores: make(map[string]float32),
+		lasts:  make(map[string]time.Time),
 	}
 }
 
@@ -40,16 +46,24 @@ func (rm *simpleReputationManager) Failure(address string) {
 	rm.Lock()
 	defer rm.Unlock()
 	rm.scores[address]--
+	rm.lasts[address] = time.Now()
 }
 
 func (rm *simpleReputationManager) Success(address string) {
 	rm.Lock()
 	defer rm.Unlock()
 	rm.scores[address]++
+	rm.lasts[address] = time.Now()
 }
 
 func (rm *simpleReputationManager) Score(address string) float32 {
 	rm.Lock()
 	defer rm.Unlock()
 	return rm.scores[address]
+}
+
+func (rm *simpleReputationManager) Last(address string) time.Time {
+	rm.Lock()
+	defer rm.Unlock()
+	return rm.lasts[address]
 }

--- a/network/reputationManager.go
+++ b/network/reputationManager.go
@@ -20,9 +20,7 @@ package network
 import "sync"
 
 type reputationManager interface {
-	Error(address string)
 	Failure(address string)
-	Invalid(address string)
 	Success(address string)
 	Score(address string) float32
 }
@@ -38,22 +36,10 @@ func newSimpleReputationManager() *simpleReputationManager {
 	}
 }
 
-func (rm *simpleReputationManager) Error(address string) {
-	rm.Lock()
-	defer rm.Unlock()
-	rm.scores[address]--
-}
-
 func (rm *simpleReputationManager) Failure(address string) {
 	rm.Lock()
 	defer rm.Unlock()
 	rm.scores[address]--
-}
-
-func (rm *simpleReputationManager) Invalid(address string) {
-	rm.Lock()
-	defer rm.Unlock()
-	rm.scores[address] = 0
 }
 
 func (rm *simpleReputationManager) Success(address string) {

--- a/network/reputationManager_test.go
+++ b/network/reputationManager_test.go
@@ -19,6 +19,7 @@ package network
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -29,23 +30,25 @@ func TestNewReputationManager(t *testing.T) {
 }
 
 func TestReputationManagerFailure(t *testing.T) {
-	score := float32(13)
 	address := "192.0.2.100:1337"
 	rep := simpleReputationManager{
-		scores: map[string]float32{address: score},
+		scores: make(map[string]float32),
+		lasts:  make(map[string]time.Time),
 	}
 	rep.Failure(address)
-	assert.Equal(t, score-1, rep.scores[address])
+	assert.Equal(t, float32(-1), rep.scores[address])
+	assert.WithinDuration(t, time.Now(), rep.lasts[address], time.Second)
 }
 
 func TestReputationManagerSuccess(t *testing.T) {
-	score := float32(13)
 	address := "192.0.2.100:1337"
 	rep := simpleReputationManager{
-		scores: map[string]float32{address: score},
+		scores: make(map[string]float32),
+		lasts:  make(map[string]time.Time),
 	}
 	rep.Success(address)
-	assert.Equal(t, score+1, rep.scores[address])
+	assert.Equal(t, float32(1), rep.scores[address])
+	assert.WithinDuration(t, time.Now(), rep.lasts[address], time.Second)
 }
 
 func TestReputationManagerScore(t *testing.T) {
@@ -55,4 +58,15 @@ func TestReputationManagerScore(t *testing.T) {
 		scores: map[string]float32{address: score},
 	}
 	assert.Equal(t, score, rep.Score(address))
+	assert.Equal(t, float32(0), rep.Score("whatever"))
+}
+
+func TestReputationManagerLast(t *testing.T) {
+	last := time.Now()
+	address := "192.0.2.100:1337"
+	rep := simpleReputationManager{
+		lasts: map[string]time.Time{address: last},
+	}
+	assert.Equal(t, last, rep.Last(address))
+	assert.Equal(t, time.Time{}, rep.Last("whatever"))
 }

--- a/network/reputationManager_test.go
+++ b/network/reputationManager_test.go
@@ -28,16 +28,6 @@ func TestNewReputationManager(t *testing.T) {
 	assert.NotNil(t, rep.scores)
 }
 
-func TestReputationManagerError(t *testing.T) {
-	score := float32(13)
-	address := "192.0.2.100:1337"
-	rep := simpleReputationManager{
-		scores: map[string]float32{address: score},
-	}
-	rep.Error(address)
-	assert.Equal(t, score-1, rep.scores[address])
-}
-
 func TestReputationManagerFailure(t *testing.T) {
 	score := float32(13)
 	address := "192.0.2.100:1337"
@@ -46,16 +36,6 @@ func TestReputationManagerFailure(t *testing.T) {
 	}
 	rep.Failure(address)
 	assert.Equal(t, score-1, rep.scores[address])
-}
-
-func TestReputationManagerInvalid(t *testing.T) {
-	score := float32(13)
-	address := "192.0.2.100:1337"
-	rep := simpleReputationManager{
-		scores: map[string]float32{address: score},
-	}
-	rep.Invalid(address)
-	assert.Equal(t, float32(0), rep.scores[address])
 }
 
 func TestReputationManagerSuccess(t *testing.T) {

--- a/network/sender.go
+++ b/network/sender.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func handleSending(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager, rep reputationManager, address string, output <-chan interface{}, w io.Writer) {
+func handleSending(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, rep reputationManager, address string, output <-chan interface{}, w io.Writer) {
 	defer wg.Done()
 
 	// extract configuration parameters

--- a/network/sender.go
+++ b/network/sender.go
@@ -47,11 +47,7 @@ func handleSending(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers pe
 		}
 		if err != nil {
 			log.Error().Err(err).Msg("could not write message")
-			rep.Error(address)
-			err = peers.Drop(address)
-			if err != nil {
-				log.Error().Err(err).Msg("could not drop peer")
-			}
+			rep.Failure(address)
 			continue
 		}
 	}

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -43,7 +43,7 @@ func (suite *Server) SetupTest() {
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
 	suite.cfg = Config{
-		interval: 10 * time.Millisecond,
+		interval: 2 * time.Millisecond,
 		maxPeers: 5,
 	}
 }
@@ -62,7 +62,7 @@ func (suite *Server) TestServerSuccess() {
 	// act
 	suite.cfg.listen = true
 	go handleServing(suite.log, &suite.wg, &suite.cfg, peers, handlers, stop)
-	time.Sleep(25 * time.Millisecond)
+	time.Sleep(time.Duration(1.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 
@@ -84,7 +84,7 @@ func (suite *Server) TestServerMaxPeersNotRunning() {
 	// act
 	suite.cfg.listen = true
 	go handleServing(suite.log, &suite.wg, &suite.cfg, peers, handlers, stop)
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(time.Duration(1.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 
@@ -106,7 +106,7 @@ func (suite *Server) TestServerNotListening() {
 	// act
 	suite.cfg.listen = false
 	go handleServing(suite.log, &suite.wg, &suite.cfg, peers, handlers, stop)
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(time.Duration(1.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 
@@ -129,7 +129,7 @@ func (suite *Server) TestServerMaxPeersRunning() {
 	// act
 	suite.cfg.listen = true
 	go handleServing(suite.log, &suite.wg, &suite.cfg, peers, handlers, stop)
-	time.Sleep(35 * time.Millisecond)
+	time.Sleep(time.Duration(3.5 * float64(suite.cfg.interval)))
 	close(stop)
 	suite.wg.Wait()
 

--- a/network/sorts.go
+++ b/network/sorts.go
@@ -30,7 +30,7 @@ func byRandom() func(string, string) bool {
 	}
 }
 
-func byReputation(rep reputationManager) func(string, string) bool {
+func byScore(rep reputationManager) func(string, string) bool {
 	return func(address1 string, address2 string) bool {
 		return rep.Score(address1) > rep.Score(address2)
 	}

--- a/network/sorts_test.go
+++ b/network/sorts_test.go
@@ -41,11 +41,11 @@ func TestByRandom(t *testing.T) {
 	assert.True(t, mismatch, "By random sort always returns same result")
 }
 
-func TestByReputation(t *testing.T) {
+func TestByScore(t *testing.T) {
 	address1 := "192.0.2.100:1337"
 	address2 := "192.0.2.200:1337"
 	rep := newSimpleReputationManager()
-	sort := byReputation(rep)
+	sort := byScore(rep)
 	vectors := map[string]struct {
 		score1   float32
 		score2   float32


### PR DESCRIPTION
This PR fixes up the main file to properly launch the node so it's possible to launch multiple ones for testing purposes.

It fixes & improves a number of things as a result of the manual testing:

- Reputation manager now handles all failures the same and should only be used for temporary failures. Permanent failures that make a peer invalid instead block the address in the address manager.

- The reputation manager now keeps track of when a peer had its last failure or success event. When trying to connect, we now make sure we don't connect to peers more than once every 15 minutes. We also apply a threshold score to make sure we give up after 5 times.

- On all tests, we fixed the `AssertNotCalled` checks to use placeholder arguments; apparently it doesn't match unless checked with the exact/wildcard arguments provided.

- We initialize the wrappers for listen & dial function and properly add to the wait group when handlers are launched.

- We removed the output function from the peer manager and instead gave it a direct `Send` function; this way, we can be sure access to the channel is guarded by the mutex and we don't close the channel before the send is completed. We also wrap it in a select, so that sends fail when a peer output channel is full.

- When dropping a peer, we delete it from the map, before trying to close the connection. Even if the close fails, it should no longer be in the map to avoid issues with sending on closed channels.

- Out of sender, receiver and processor, only the processor will drop the peer on timeout. Receiver will start the cascade by closing the input channel on closed network connection. The two others will have a draining/blocking wait on the channel they read from until it is closed to cleanly finish the cascade.

- Vendored dependencies updated to latest available tags.