### PR TITLE
Implement binary trie

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -55,6 +55,12 @@
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/jrick/bitset"
+  packages = ["."]
+  revision = "06eae37cdf93c699c0503c23f998167ce841974c"
+
+[[projects]]
   name = "github.com/pierrec/lz4"
   packages = ["."]
   revision = "2fcda4cb7018ce05a25959d2fe08c83e3329f169"
@@ -159,6 +165,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7d3d496368d5cf0fc82d7d73c43261c82b948acb66539c32579356b9f79c3268"
+  inputs-digest = "4070e470b5b415f161251fc1534465ec3dc8e69c8aa35a2b96447c53d4732b23"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -142,19 +142,19 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["blake2b","pbkdf2"]
-  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
+  revision = "c4a91bd4f524f10d064139674cf55852e055ad01"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","internal/timeseries","trace"]
-  revision = "d25186b37f34ebdbbea8f488ef055638dfab272d"
+  revision = "892bf7b0c6e2f93b51166bf3882e50277fa5afc6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
+  revision = "8c0ece68c28377f4c326d85b94f8df0dace46f80"
 
 [[projects]]
   name = "zombiezen.com/go/capnproto2"
@@ -165,6 +165,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4070e470b5b415f161251fc1534465ec3dc8e69c8aa35a2b96447c53d4732b23"
+  inputs-digest = "209a984370549c1ee36393c603f1e55fd1643a5368af67fdec18687866b4690a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,6 +38,10 @@
   name = "github.com/hashicorp/go-multierror"
 
 [[constraint]]
+  branch = "master"
+  name = "github.com/jrick/bitset"
+
+[[constraint]]
   name = "github.com/pierrec/lz4"
   version = "1.1.0"
 

--- a/node/node.go
+++ b/node/node.go
@@ -79,7 +79,7 @@ func New(log zerolog.Logger, net Network, chain Blockchain, finder Finder, codec
 	n.peers = peers
 
 	// initialize simple transaction pool
-	store := trie.New()
+	store := trie.NewBin()
 	pool := newPool(codec, store)
 	n.pool = pool
 

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -82,6 +82,27 @@ func BenchmarkBinDelete(b *testing.B) {
 	}
 }
 
+func BenchmarkBinHash(b *testing.B) {
+	t := NewBin()
+	keys := make([][]byte, 0, b.N)
+	hashes := make([][]byte, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := make([]byte, 32)
+		hash := make([]byte, 32)
+		_, _ = rand.Read(key)
+		_, _ = rand.Read(hash)
+		keys = append(keys, key)
+		hashes = append(hashes, hash)
+	}
+	for i := 0; i < b.N; i++ {
+		t.MustPut(keys[i], hashes[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.Hash()
+	}
+}
+
 func BenchmarkHexInsert(b *testing.B) {
 	t := NewHex()
 	keys := make([][]byte, 0, b.N)
@@ -139,5 +160,26 @@ func BenchmarkHexDelete(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		t.Del(keys[i])
+	}
+}
+
+func BenchmarkHexHash(b *testing.B) {
+	t := NewHex()
+	keys := make([][]byte, 0, b.N)
+	hashes := make([][]byte, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := make([]byte, 32)
+		hash := make([]byte, 32)
+		_, _ = rand.Read(key)
+		_, _ = rand.Read(hash)
+		keys = append(keys, key)
+		hashes = append(hashes, hash)
+	}
+	for i := 0; i < b.N; i++ {
+		t.MustPut(keys[i], hashes[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.Hash()
 	}
 }

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"crypto/rand"
+	"testing"
+)
+
+func BenchmarkBinInsert(b *testing.B) {
+	t := NewBin()
+	keys := make([][]byte, 0, b.N)
+	hashes := make([][]byte, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := make([]byte, 32)
+		hash := make([]byte, 32)
+		_, _ = rand.Read(key)
+		_, _ = rand.Read(hash)
+		keys = append(keys, key)
+		hashes = append(hashes, hash)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.MustPut(keys[i], hashes[i])
+	}
+}
+
+func BenchmarkBinRetrieve(b *testing.B) {
+	t := NewBin()
+	keys := make([][]byte, 0, b.N)
+	hashes := make([][]byte, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := make([]byte, 32)
+		hash := make([]byte, 32)
+		_, _ = rand.Read(key)
+		_, _ = rand.Read(hash)
+		keys = append(keys, key)
+		hashes = append(hashes, hash)
+	}
+	for i := 0; i < b.N; i++ {
+		t.MustPut(keys[i], hashes[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.Get(keys[i])
+	}
+}
+
+func BenchmarkBinDelete(b *testing.B) {
+	t := NewBin()
+	keys := make([][]byte, 0, b.N)
+	hashes := make([][]byte, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := make([]byte, 32)
+		hash := make([]byte, 32)
+		_, _ = rand.Read(key)
+		_, _ = rand.Read(hash)
+		keys = append(keys, key)
+		hashes = append(hashes, hash)
+	}
+	for i := 0; i < b.N; i++ {
+		t.MustPut(keys[i], hashes[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.Del(keys[i])
+	}
+}
+
+func BenchmarkHexInsert(b *testing.B) {
+	t := NewHex()
+	keys := make([][]byte, 0, b.N)
+	hashes := make([][]byte, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := make([]byte, 32)
+		hash := make([]byte, 32)
+		_, _ = rand.Read(key)
+		_, _ = rand.Read(hash)
+		keys = append(keys, key)
+		hashes = append(hashes, hash)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.MustPut(keys[i], hashes[i])
+	}
+}
+
+func BenchmarkHexRetrieve(b *testing.B) {
+	t := NewHex()
+	keys := make([][]byte, 0, b.N)
+	hashes := make([][]byte, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := make([]byte, 32)
+		hash := make([]byte, 32)
+		_, _ = rand.Read(key)
+		_, _ = rand.Read(hash)
+		keys = append(keys, key)
+		hashes = append(hashes, hash)
+	}
+	for i := 0; i < b.N; i++ {
+		t.MustPut(keys[i], hashes[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.Get(keys[i])
+	}
+}
+
+func BenchmarkHexDelete(b *testing.B) {
+	t := NewHex()
+	keys := make([][]byte, 0, b.N)
+	hashes := make([][]byte, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := make([]byte, 32)
+		hash := make([]byte, 32)
+		_, _ = rand.Read(key)
+		_, _ = rand.Read(hash)
+		keys = append(keys, key)
+		hashes = append(hashes, hash)
+	}
+	for i := 0; i < b.N; i++ {
+		t.MustPut(keys[i], hashes[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t.Del(keys[i])
+	}
+}

--- a/trie/bin.go
+++ b/trie/bin.go
@@ -298,37 +298,35 @@ Remove:
 // root node. Currently, it does not do any caching and recomputes the hash from the leafs up. If
 // the root is not initialized, it will return the hash of an empty byte array to uniquely represent
 // a trie without state.
-// func (t *Bin) Hash() []byte {
-// 	return t.nodeHash(t.root)
-// }
+func (t *Bin) Hash() []byte {
+	return t.nodeHash(t.root)
+}
 
 // nodeHash will return the hash of a given node.
-// func (t *Bin) nodeHash(node node) []byte {
-// 	switch n := node.(type) {
-// 	case *hexNode:
-// 		var hashes [][]byte
-// 		for _, child := range n.children {
-// 			hashes = append(hashes, t.nodeHash(child))
-// 		}
-// 		t.h.Reset()
-// 		for _, hash := range hashes {
-// 			t.h.Write(hash)
-// 		}
-// 		return t.h.Sum(nil)
-// 	case *shortNode:
-// 		hash := t.nodeHash(n.child)
-// 		t.h.Reset()
-// 		t.h.Write(n.key)
-// 		t.h.Write(hash)
-// 		return t.h.Sum(nil)
-// 	case valueNode:
-// 		t.h.Reset()
-// 		t.h.Write([]byte(n))
-// 		return t.h.Sum(nil)
-// 	case nil:
-// 		t.h.Reset()
-// 		return t.h.Sum(nil)
-// 	default:
-// 		panic("invalid node type")
-// 	}
-// }
+func (t *Bin) nodeHash(node node) []byte {
+	switch n := node.(type) {
+	case *binFull:
+		left := t.nodeHash(n.left)
+		right := t.nodeHash(n.right)
+		t.h.Reset()
+		t.h.Write(left)
+		t.h.Write(right)
+		return t.h.Sum(nil)
+	case *binShort:
+		hash := t.nodeHash(n.child)
+		t.h.Reset()
+		t.h.Write([]byte{byte(n.count)})
+		t.h.Write(n.path)
+		t.h.Write(hash)
+		return t.h.Sum(nil)
+	case value:
+		t.h.Reset()
+		t.h.Write([]byte(n))
+		return t.h.Sum(nil)
+	case nil:
+		t.h.Reset()
+		return t.h.Sum(nil)
+	default:
+		panic("invalid node type")
+	}
+}

--- a/trie/bin.go
+++ b/trie/bin.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"hash"
+
+	"github.com/jrick/bitset"
+	"golang.org/x/crypto/blake2b"
+)
+
+// Bin represents our own implementation of the patricia merkle trie as specified in the Ethereum
+// yellow paper, with a few simplications due to the simpler structure of the Alvalor blockchain.
+type Bin struct {
+	root node
+	h    hash.Hash
+}
+
+// NewBin creates a new empty hex trie.
+func NewBin() *Bin {
+	h, _ := blake2b.New256(nil)
+	t := &Bin{h: h}
+	return t
+}
+
+// Put will insert the given data for the given key. It will fail if there already is data with the given key.
+func (t *Bin) Put(key []byte, data []byte) error {
+	return t.put(key, data, false)
+}
+
+// MustPut will insert the given data for the given key and will overwrite any data that might already be stored under
+// the given key.
+func (t *Bin) MustPut(key []byte, data []byte) {
+	t.put(key, data, true)
+}
+
+func (t *Bin) put(key []byte, data []byte, force bool) error {
+	cur := &t.root
+	path := bitset.Bytes(key)
+	index := uint(0)
+	for {
+		switch n := (*cur).(type) {
+
+		// full binary node has one left and one right child
+		case *binFull:
+
+			// go left for zero and right for one
+			if !path.Get(int(index)) {
+				cur = &n.left
+			} else {
+				cur = &n.right
+			}
+			index++
+
+		// short binary node has path length, path and child
+		case *binShort:
+
+			// find the amount of common bits between insert path and node path
+			nodePath := bitset.Bytes(n.path)
+			var commonCount uint
+			for i := uint(0); i < n.count; i++ {
+				if path.Get(int(i+index)) != nodePath.Get(int(i)) {
+					break
+				}
+				commonCount++
+			}
+
+			// if we have the whole node path in common, simply forward to child
+			if commonCount == n.count {
+				cur = &n.child
+				index = index + commonCount
+				continue
+			}
+
+			// if we have a common count, we insert a common short node first
+			if commonCount > 0 {
+				commonPath := bitset.NewBytes(int(commonCount))
+				for i := uint(0); i < commonCount; i++ {
+					commonPath.SetBool(int(i), path.Get(int(i+index)))
+				}
+				commonNode := &binShort{count: commonCount, path: commonPath}
+				*cur = commonNode
+				cur = &commonNode.child
+				index = index + commonCount
+			}
+
+			// then we always insert the node where we split
+			var remain *node
+			splitNode := &binFull{}
+			*cur = splitNode
+			if nodePath.Get(int(commonCount)) {
+				cur = &splitNode.left
+				remain = &splitNode.right
+			} else {
+				cur = &splitNode.right
+				remain = &splitNode.left
+			}
+			index++
+
+			// if we have remaining path on the initial short node, we insert it
+			remainCount := n.count - commonCount - 1
+			if remainCount > 0 {
+				remainPath := bitset.NewBytes(int(remainCount))
+				for i := uint(0); i < remainCount; i++ {
+					remainPath.SetBool(int(i), nodePath.Get(int(i+commonCount+1)))
+				}
+				remainNode := &binShort{count: remainCount, path: remainPath}
+				*remain = remainNode
+				remain = &remainNode.child
+			}
+
+			// finally, we insert the child of the initial short node
+			*remain = n.child
+
+		case value:
+			if !force {
+				return ErrAlreadyExists
+			}
+			*cur = nil
+
+		case nil:
+			if index < 255 {
+				remainCount := 255 - index
+				remainPath := bitset.NewBytes(int(remainCount))
+				for i := uint(0); i < remainCount; i++ {
+					remainPath.SetBool(int(i), path.Get(int(index+i)))
+				}
+				remainNode := &binShort{count: remainCount, path: remainPath}
+				*cur = remainNode
+				cur = &remainNode.child
+				index = 255
+				continue
+			}
+			*cur = value(data)
+			return nil
+		}
+	}
+}
+
+// Get will retrieve the hash located at the path provided by the given key. If the path doesn't
+// exist or there is no hash at the given location, it returns a nil slice and false.
+// func (t *Bin) Get(key []byte) ([]byte, error) {
+// 	cur := &t.root
+// 	path := encode(key)
+// 	for {
+// 		switch n := (*cur).(type) {
+// 		case *hexNode:
+// 			cur = &n.children[path[0]]
+// 			path = path[1:]
+// 		case *shortNode:
+// 			var common []byte
+// 			for i := 0; i < len(n.key); i++ {
+// 				if path[i] != n.key[i] {
+// 					break
+// 				}
+// 				common = append(common, path[i])
+// 			}
+// 			if len(common) == len(n.key) {
+// 				cur = &n.child
+// 				path = path[len(common):]
+// 				continue
+// 			}
+// 			return nil, ErrNotFound
+// 		case valueNode:
+// 			return []byte(n), nil
+// 		case nil:
+// 			return nil, ErrNotFound
+// 		}
+// 	}
+// }
+
+// Del will try to delete the hash located at the path provided by the given key. If no hash is
+// found at the given location, it returns false.
+// func (t *Bin) Del(key []byte) error {
+// 	var visited []*node
+// 	cur := &t.root
+// 	path := encode(key)
+// Remove:
+// 	for {
+// 		switch n := (*cur).(type) {
+// 		case *hexNode:
+// 			visited = append(visited, cur)
+// 			cur = &n.children[path[0]]
+// 			path = path[1:]
+// 		case *shortNode:
+// 			visited = append(visited, cur)
+// 			var common []byte
+// 			for i := 0; i < len(n.key); i++ {
+// 				if path[i] != n.key[i] {
+// 					break
+// 				}
+// 				common = append(common, path[i])
+// 			}
+// 			if len(common) == len(n.key) {
+// 				cur = &n.child
+// 				path = path[len(common):]
+// 				continue
+// 			}
+// 			return ErrNotFound
+// 		case valueNode:
+// 			*cur = nil
+// 			break Remove
+// 		case nil:
+// 			return ErrNotFound
+// 		}
+// 	}
+// Compact:
+// 	for len(visited) > 0 {
+// 		cur = visited[len(visited)-1]
+// 		switch n := (*cur).(type) {
+// 		case *shortNode:
+// 			*cur = nil
+// 			visited = visited[:len(visited)-1]
+// 			continue Compact
+// 		case *hexNode:
+// 			var index int
+// 			var child node
+// 			count := 0
+// 			for i, c := range n.children {
+// 				if c != nil {
+// 					index = i
+// 					child = c
+// 					count++
+// 				}
+// 			}
+// 			if count > 1 {
+// 				break Compact
+// 			}
+// 			short := shortNode{
+// 				key:   []byte{byte(index)},
+// 				child: child,
+// 			}
+// 			c, ok := child.(*shortNode)
+// 			if ok {
+// 				short.key = append(short.key, c.key...)
+// 				short.child = c.child
+// 			}
+// 			*cur = &short
+// 			if len(visited) > 1 {
+// 				parent := visited[len(visited)-2]
+// 				p, ok := (*parent).(*shortNode)
+// 				if ok {
+// 					p.key = append(p.key, short.key...)
+// 					p.child = short.child
+// 				}
+// 			}
+// 			break Compact
+// 		}
+// 	}
+// 	return nil
+// }
+
+// Hash will return the hash that represents the trie in its entirety by returning the hash of the
+// root node. Currently, it does not do any caching and recomputes the hash from the leafs up. If
+// the root is not initialized, it will return the hash of an empty byte array to uniquely represent
+// a trie without state.
+// func (t *Bin) Hash() []byte {
+// 	return t.nodeHash(t.root)
+// }
+
+// nodeHash will return the hash of a given node.
+// func (t *Bin) nodeHash(node node) []byte {
+// 	switch n := node.(type) {
+// 	case *hexNode:
+// 		var hashes [][]byte
+// 		for _, child := range n.children {
+// 			hashes = append(hashes, t.nodeHash(child))
+// 		}
+// 		t.h.Reset()
+// 		for _, hash := range hashes {
+// 			t.h.Write(hash)
+// 		}
+// 		return t.h.Sum(nil)
+// 	case *shortNode:
+// 		hash := t.nodeHash(n.child)
+// 		t.h.Reset()
+// 		t.h.Write(n.key)
+// 		t.h.Write(hash)
+// 		return t.h.Sum(nil)
+// 	case valueNode:
+// 		t.h.Reset()
+// 		t.h.Write([]byte(n))
+// 		return t.h.Sum(nil)
+// 	case nil:
+// 		t.h.Reset()
+// 		return t.h.Sum(nil)
+// 	default:
+// 		panic("invalid node type")
+// 	}
+// }

--- a/trie/bin.go
+++ b/trie/bin.go
@@ -49,11 +49,6 @@ func (t *Bin) MustPut(key []byte, data []byte) {
 	t.put(key, data, true)
 }
 
-// func modify(i int) int {
-// 	i = ((i / 8) * 8) + (7 - i%8)
-// 	return i
-// }
-
 func (t *Bin) put(key []byte, data []byte, force bool) error {
 	cur := &t.root
 	path := bitset.Bytes(key)

--- a/trie/bin.go
+++ b/trie/bin.go
@@ -209,6 +209,8 @@ Remove:
 		case value:
 			*cur = nil
 			break Remove
+		case nil:
+			return ErrNotFound
 		}
 	}
 	_, ok := (*last).(*binShort)
@@ -224,10 +226,10 @@ Remove:
 	var n *binShort
 	newPath := bitset.NewBytes(1)
 	if l.left != nil {
-		newPath.Unset(0)
+		newPath.SetBool(0, false)
 		n = &binShort{count: 1, path: newPath, child: l.left}
 	} else {
-		newPath.Set(0)
+		newPath.SetBool(0, true)
 		n = &binShort{count: 1, path: newPath, child: l.right}
 	}
 	*last = n

--- a/trie/bin.go
+++ b/trie/bin.go
@@ -245,6 +245,11 @@ Remove:
 		visited = visited[:len(visited)-1]
 	}
 
+	// if we only had the short node, it was root and we are done
+	if len(visited) == 0 {
+		return nil
+	}
+
 	// the deleted node (or short node) was attached to a full node or was root
 	last = visited[len(visited)-1]
 	l, ok := (*last).(*binFull)
@@ -262,6 +267,7 @@ Remove:
 		sub = &binShort{count: 1, path: []byte{1}, child: l.right}
 	}
 	*last = sub
+	visited = visited[:len(visited)-1]
 
 	// if the child is a short node, the full node wasn't last node before the remaining value node
 	// merge the child node into the substitute node
@@ -273,16 +279,16 @@ Remove:
 	}
 
 	// if there is no parent, the new short node is root and we are done
-	if len(visited) == 1 {
+	if len(visited) == 0 {
 		return nil
 	}
 
 	// otherwise, the parent could be another short node
-	parent := visited[len(visited)-2]
+	parent := visited[len(visited)-1]
 	p, ok := (*parent).(*binShort)
 
 	// if the parent is not a short node, it's a full node and we are done
-	if ok {
+	if !ok {
 		return nil
 	}
 

--- a/trie/bin_test.go
+++ b/trie/bin_test.go
@@ -1,20 +1,20 @@
-// // Copyright (c) 2017 The Alvalor Authors
-// //
-// // This file is part of Alvalor.
-// //
-// // Alvalor is free software: you can redistribute it and/or modify
-// // it under the terms of the GNU Affero General Public License as published by
-// // the Free Software Foundation, either version 3 of the License, or
-// // (at your option) any later version.
-// //
-// // Alvalor is distributed in the hope that it will be useful,
-// // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// // GNU Affero General Public License for more details.
-// //
-// // You should have received a copy of the GNU Affero General Public License
-// // along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright (c) 2017 The Alvalor Authors
 //
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
 package trie
 
 import (

--- a/trie/bin_test.go
+++ b/trie/bin_test.go
@@ -36,22 +36,22 @@ func TestBinSingle(t *testing.T) {
 		_, _ = rand.Read(hash)
 		err := trie.Put(key, hash)
 		if err != nil {
-			t.Fatalf("could not put: %x", key)
+			t.Fatalf("could not put: %x (%v)", key, err)
 		}
 		out, err := trie.Get(key)
 		if err != nil {
-			t.Fatalf("could not get: %x", key)
+			t.Fatalf("could not get: %x (%v)", key, err)
 		}
 		if !bytes.Equal(out, hash) {
 			t.Errorf("wrong hash: %x != %x", out, hash)
 		}
 		err = trie.Del(key)
 		if err != nil {
-			t.Fatalf("could not del: %x", key)
+			t.Fatalf("could not del: %x (%v)", key, err)
 		}
 		_, err = trie.Get(key)
 		if err == nil {
-			t.Fatalf("should not get: %x", key)
+			t.Fatalf("should not get: %x (%v)", key, err)
 		}
 	}
 }
@@ -73,13 +73,13 @@ func TestBinBatch(t *testing.T) {
 		hash := hashes[i]
 		err := trie.Put(key, hash)
 		if err != nil {
-			t.Fatalf("could not put %v: %x", i, key)
+			t.Fatalf("could not put %v: %x (%v)", i, key, err)
 		}
 	}
 	for i, key := range keys {
 		out, err := trie.Get(key)
 		if err != nil {
-			t.Fatalf("could not get %v: %x", i, key)
+			t.Fatalf("could not get %v: %x (%v)", i, key, err)
 		}
 		hash := hashes[i]
 		if !bytes.Equal(out, hash) {
@@ -89,7 +89,7 @@ func TestBinBatch(t *testing.T) {
 	for i, key := range keys {
 		err := trie.Del(key)
 		if err != nil {
-			t.Fatalf("could not del %v: %x", i, key)
+			t.Fatalf("could not del %v: %x (%v)", i, key, err)
 		}
 	}
 	zero := trie.h.Sum(nil)

--- a/trie/bin_test.go
+++ b/trie/bin_test.go
@@ -1,20 +1,20 @@
-// Copyright (c) 2017 The Alvalor Authors
+// // Copyright (c) 2017 The Alvalor Authors
+// //
+// // This file is part of Alvalor.
+// //
+// // Alvalor is free software: you can redistribute it and/or modify
+// // it under the terms of the GNU Affero General Public License as published by
+// // the Free Software Foundation, either version 3 of the License, or
+// // (at your option) any later version.
+// //
+// // Alvalor is distributed in the hope that it will be useful,
+// // but WITHOUT ANY WARRANTY; without even the implied warranty of
+// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// // GNU Affero General Public License for more details.
+// //
+// // You should have received a copy of the GNU Affero General Public License
+// // along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
 //
-// This file is part of Alvalor.
-//
-// Alvalor is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Alvalor is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (
@@ -29,6 +29,7 @@ const BinTestLength = 100000
 func TestBinSingle(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	trie := NewBin()
+	zero := trie.h.Sum(nil)
 	for i := 0; i < BinTestLength; i++ {
 		key := make([]byte, 32)
 		hash := make([]byte, 32)
@@ -52,6 +53,10 @@ func TestBinSingle(t *testing.T) {
 		_, err = trie.Get(key)
 		if err == nil {
 			t.Fatalf("should not get: %x (%v)", key, err)
+		}
+		hash = trie.Hash()
+		if !bytes.Equal(hash, zero) {
+			t.Fatalf("root hash not zero: %x != %x", hash, zero)
 		}
 	}
 }

--- a/trie/bin_test.go
+++ b/trie/bin_test.go
@@ -24,12 +24,12 @@ import (
 	"time"
 )
 
-const HexTestLength = 100000
+const BinTestLength = 100000
 
-func TestHexSingle(t *testing.T) {
+func TestBinSingle(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	trie := NewHex()
-	for i := 0; i < HexTestLength; i++ {
+	trie := NewBin()
+	for i := 0; i < BinTestLength; i++ {
 		key := make([]byte, 32)
 		hash := make([]byte, 32)
 		_, _ = rand.Read(key)
@@ -56,12 +56,12 @@ func TestHexSingle(t *testing.T) {
 	}
 }
 
-func TestHexBatch(t *testing.T) {
+func TestBinBatch(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	trie := NewHex()
-	keys := make([][]byte, 0, HexTestLength)
-	hashes := make([][]byte, 0, HexTestLength)
-	for i := 0; i < HexTestLength; i++ {
+	trie := NewBin()
+	keys := make([][]byte, 0, BinTestLength)
+	hashes := make([][]byte, 0, BinTestLength)
+	for i := 0; i < BinTestLength; i++ {
 		key := make([]byte, 32)
 		hash := make([]byte, 32)
 		_, _ = rand.Read(key)

--- a/trie/hex.go
+++ b/trie/hex.go
@@ -30,32 +30,32 @@ var (
 	ErrNotFound      = errors.New("key not found")
 )
 
-// Trie represents our own implementation of the patricia merkle trie as specified in the Ethereum
+// Hex represents our own implementation of the patricia merkle trie as specified in the Ethereum
 // yellow paper, with a few simplications due to the simpler structure of the Alvalor blockchain.
-type Trie struct {
+type Hex struct {
 	root node
 	h    hash.Hash
 }
 
-// New creates a new empty trie with no state.
-func New() *Trie {
+// NewHex creates a new empty hex trie.
+func NewHex() *Hex {
 	h, _ := blake2b.New256(nil)
-	t := &Trie{h: h}
+	t := &Hex{h: h}
 	return t
 }
 
 // Put will insert the given data for the given key. It will fail if there already is data with the given key.
-func (t *Trie) Put(key []byte, data []byte) error {
+func (t *Hex) Put(key []byte, data []byte) error {
 	return t.put(key, data, false)
 }
 
 // MustPut will insert the given data for the given key and will overwrite any data that might already be stored under
 // the given key.
-func (t *Trie) MustPut(key []byte, data []byte) {
+func (t *Hex) MustPut(key []byte, data []byte) {
 	t.put(key, data, true)
 }
 
-func (t *Trie) put(key []byte, data []byte, force bool) error {
+func (t *Hex) put(key []byte, data []byte, force bool) error {
 	cur := &t.root
 	path := encode(key)
 	for {
@@ -116,7 +116,7 @@ func (t *Trie) put(key []byte, data []byte, force bool) error {
 
 // Get will retrieve the hash located at the path provided by the given key. If the path doesn't
 // exist or there is no hash at the given location, it returns a nil slice and false.
-func (t *Trie) Get(key []byte) ([]byte, error) {
+func (t *Hex) Get(key []byte) ([]byte, error) {
 	cur := &t.root
 	path := encode(key)
 	for {
@@ -148,7 +148,7 @@ func (t *Trie) Get(key []byte) ([]byte, error) {
 
 // Del will try to delete the hash located at the path provided by the given key. If no hash is
 // found at the given location, it returns false.
-func (t *Trie) Del(key []byte) error {
+func (t *Hex) Del(key []byte) error {
 	var visited []*node
 	cur := &t.root
 	path := encode(key)
@@ -231,12 +231,12 @@ Compact:
 // root node. Currently, it does not do any caching and recomputes the hash from the leafs up. If
 // the root is not initialized, it will return the hash of an empty byte array to uniquely represent
 // a trie without state.
-func (t *Trie) Hash() []byte {
+func (t *Hex) Hash() []byte {
 	return t.nodeHash(t.root)
 }
 
 // nodeHash will return the hash of a given node.
-func (t *Trie) nodeHash(node node) []byte {
+func (t *Hex) nodeHash(node node) []byte {
 	switch n := node.(type) {
 	case *fullNode:
 		var hashes [][]byte

--- a/trie/hex_test.go
+++ b/trie/hex_test.go
@@ -28,7 +28,7 @@ const TestLength = 1000000
 
 func TestSingle(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	trie := New()
+	trie := NewHex()
 	for i := 0; i < TestLength; i++ {
 		key := make([]byte, 32)
 		hash := make([]byte, 32)
@@ -58,7 +58,7 @@ func TestSingle(t *testing.T) {
 
 func TestBatch(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	trie := New()
+	trie := NewHex()
 	keys := make([][]byte, 0, TestLength)
 	hashes := make([][]byte, 0, TestLength)
 	for i := 0; i < TestLength; i++ {

--- a/trie/node.go
+++ b/trie/node.go
@@ -28,6 +28,9 @@ var (
 // node is simply a type definition for the empty interface.
 type node interface{}
 
+// dummy represents a dummy node used for asserts
+type dummy struct{}
+
 // valueNode represents a node that stores the data inserted as value into the trie, which
 // corresponds to the key that we traversed down the trie.
 type value []byte

--- a/trie/node.go
+++ b/trie/node.go
@@ -17,22 +17,42 @@
 
 package trie
 
+import "errors"
+
+// A list of errors that can be returned by the functions of the trie.
+var (
+	ErrAlreadyExists = errors.New("key already exists")
+	ErrNotFound      = errors.New("key not found")
+)
+
 // node is simply a type definition for the empty interface.
 type node interface{}
 
 // valueNode represents a node that stores the data inserted as value into the trie, which
 // corresponds to the key that we traversed down the trie.
-type valueNode []byte
+type value []byte
 
 // shortNode represents a combined single path through what would otherwise be several full nodes.
 // It holds the key of the traversed path and a reference to the child node.
-type shortNode struct {
+type hexShort struct {
 	key   []byte
 	child node
 }
 
-// fullNode represents a full node in the patricia merkle trie that has sixteen children, one per
+type binShort struct {
+	path  []byte
+	count uint
+	child node
+}
+
+// binNode represents a full node in the binary patricia merkle tree, with one child to the left and one to the right.
+type binFull struct {
+	left  node
+	right node
+}
+
+// hexNode represents a full node in the patricia merkle trie that has sixteen children, one per
 // possible value of the next nibble of the key/path.
-type fullNode struct {
+type hexFull struct {
 	children [16]node
 }


### PR DESCRIPTION
This PR introduces a binary trie next to the hexadecimal trie. Generally, it simplifies and complicates the implementation in different places, but overall, it should be a better choice because the merkle proofs will be 4 times smaller.