### PR TITLE
Change hash type to array

### DIFF
--- a/network/peerManager_test.go
+++ b/network/peerManager_test.go
@@ -33,7 +33,7 @@ func TestNewPeerManager(t *testing.T) {
 	assert.Equal(t, handlers, peers.handlers)
 	assert.Equal(t, min, peers.min)
 	assert.Equal(t, max, peers.max)
-	assert.Equal(t, uint(16), peers.buffer)
+	assert.NotZero(t, peers.buffer)
 	assert.NotNil(t, peers.reg)
 }
 

--- a/node/blockchain.go
+++ b/node/blockchain.go
@@ -24,11 +24,11 @@ type Blockchain interface {
 	Height() uint32
 	Header() *types.Header
 	AddBlock(block *types.Block) error
-	TransactionByHash(hash []byte) (*types.Transaction, error)
-	HeightByHash(hash []byte) (uint32, error)
-	HashByHeight(height uint32) ([]byte, error)
-	HeaderByHash(hash []byte) (*types.Header, error)
+	TransactionByHash(hash types.Hash) (*types.Transaction, error)
+	HeightByHash(hash types.Hash) (uint32, error)
+	HashByHeight(height uint32) (types.Hash, error)
+	HeaderByHash(hash types.Hash) (*types.Header, error)
 	HeaderByHeight(height uint32) (*types.Header, error)
-	BlockByHash(hash []byte) (*types.Block, error)
+	BlockByHash(hash types.Hash) (*types.Block, error)
 	BlockByHeight(height uint32) (*types.Block, error)
 }

--- a/node/finder.go
+++ b/node/finder.go
@@ -17,9 +17,11 @@
 
 package node
 
+import "github.com/alvalor/alvalor-go/types"
+
 // Finder is in charge of finding the longest path in a tree of block hashes.
 type Finder interface {
-	Add(hash []byte, parent []byte) error
-	Has(hash []byte) bool
-	Path() [][]byte
+	Add(hash types.Hash, parent types.Hash) error
+	Has(hash types.Hash) bool
+	Path() []types.Hash
 }

--- a/node/handleEntity.go
+++ b/node/handleEntity.go
@@ -33,7 +33,7 @@ func handleEntity(log zerolog.Logger, wg *sync.WaitGroup, net Network, peers pee
 	)
 
 	// configure logger
-	log = log.With().Str("component", "entity").Hex("hash", hash).Logger()
+	log = log.With().Str("component", "entity").Hex("hash", hash[:]).Logger()
 	log.Debug().Msg("entity routine started")
 	defer log.Debug().Msg("entity routine stopped")
 

--- a/node/handleEvent_test.go
+++ b/node/handleEvent_test.go
@@ -62,7 +62,7 @@ func (suite *EventSuite) TestEventConnected() {
 
 	pool := &PoolMock{}
 	pool.On("Count").Return(0)
-	pool.On("IDs").Return([][]byte{})
+	pool.On("Hashes").Return([][]byte{})
 
 	handlers := &HandlersMock{}
 	handlers.On("Message", mock.Anything)

--- a/node/handlers.go
+++ b/node/handlers.go
@@ -17,9 +17,11 @@
 
 package node
 
+import "github.com/alvalor/alvalor-go/types"
+
 // Entity is any data structure that returns a unique ID.
 type Entity interface {
-	Hash() []byte
+	Hash() types.Hash
 }
 
 // Handlers describes the handlers we need to process everything.
@@ -28,5 +30,5 @@ type Handlers interface {
 	Event(event interface{})
 	Message(address string, message interface{})
 	Entity(entity Entity)
-	Collect(path [][]byte)
+	Collect(path []types.Hash)
 }

--- a/node/messages.go
+++ b/node/messages.go
@@ -26,12 +26,12 @@ import (
 // Status message shares our top block height.
 type Status struct {
 	Height uint32
-	Hash   []byte
+	Hash   types.Hash
 }
 
 // Sync requests headers we are missing.
 type Sync struct {
-	Locators [][]byte
+	Locators []types.Hash
 }
 
 // Mempool is a message containing details about the memory pool.
@@ -41,12 +41,12 @@ type Mempool struct {
 
 // Inventory is a message containing a list of transaction hashes.
 type Inventory struct {
-	IDs [][]byte
+	Hashes []types.Hash
 }
 
 // Request requests a number of transactions for the memory pool.
 type Request struct {
-	IDs [][]byte
+	Hashes []types.Hash
 }
 
 // Batch is a batch of transactions to send as one message.

--- a/node/mocks_test.go
+++ b/node/mocks_test.go
@@ -71,13 +71,13 @@ func (p *PoolMock) Add(tx *types.Transaction) error {
 	return args.Error(0)
 }
 
-func (p *PoolMock) Known(id []byte) bool {
-	args := p.Called(id)
+func (p *PoolMock) Known(hash types.Hash) bool {
+	args := p.Called(hash)
 	return args.Bool(0)
 }
 
-func (p *PoolMock) Get(id []byte) (*types.Transaction, error) {
-	args := p.Called(id)
+func (p *PoolMock) Get(hash types.Hash) (*types.Transaction, error) {
+	args := p.Called(hash)
 	var tx *types.Transaction
 	if args.Get(0) != nil {
 		tx = args.Get(0).(*types.Transaction)
@@ -85,8 +85,8 @@ func (p *PoolMock) Get(id []byte) (*types.Transaction, error) {
 	return tx, args.Error(1)
 }
 
-func (p *PoolMock) Remove(id []byte) error {
-	args := p.Called(id)
+func (p *PoolMock) Remove(hash types.Hash) error {
+	args := p.Called(hash)
 	return args.Error(0)
 }
 
@@ -95,11 +95,11 @@ func (p *PoolMock) Count() uint {
 	return uint(args.Int(0))
 }
 
-func (p *PoolMock) IDs() [][]byte {
+func (p *PoolMock) Hashes() []types.Hash {
 	args := p.Called()
-	var set [][]byte
+	var set []types.Hash
 	if args.Get(0) != nil {
-		set = args.Get(0).([][]byte)
+		set = args.Get(0).([]types.Hash)
 	}
 	return set
 }
@@ -125,12 +125,12 @@ func (p *PeersMock) Actives() []string {
 	return active
 }
 
-func (p *PeersMock) Tag(address string, id []byte) {
-	p.Called(address, id)
+func (p *PeersMock) Tag(address string, hash types.Hash) {
+	p.Called(address, hash)
 }
 
-func (p *PeersMock) Tags(id []byte) []string {
-	args := p.Called(id)
+func (p *PeersMock) Tags(hash types.Hash) []string {
+	args := p.Called(hash)
 	var seen []string
 	if args.Get(0) != nil {
 		seen = args.Get(0).([]string)
@@ -158,7 +158,7 @@ func (h *HandlersMock) Entity(entity Entity) {
 	h.Called(entity)
 }
 
-func (h *HandlersMock) Collect(path [][]byte) {
+func (h *HandlersMock) Collect(path []types.Hash) {
 	h.Called(path)
 }
 
@@ -195,7 +195,7 @@ func (b *BlockchainMock) AddBlock(block *types.Block) error {
 	return args.Error(0)
 }
 
-func (b *BlockchainMock) TransactionByHash(hash []byte) (*types.Transaction, error) {
+func (b *BlockchainMock) TransactionByHash(hash types.Hash) (*types.Transaction, error) {
 	args := b.Called(hash)
 	var tx *types.Transaction
 	if args.Get(0) != nil {
@@ -204,21 +204,17 @@ func (b *BlockchainMock) TransactionByHash(hash []byte) (*types.Transaction, err
 	return tx, args.Error(1)
 }
 
-func (b *BlockchainMock) HeightByHash(hash []byte) (uint32, error) {
+func (b *BlockchainMock) HeightByHash(hash types.Hash) (uint32, error) {
 	args := b.Called(hash)
 	return uint32(args.Int(0)), args.Error(1)
 }
 
-func (b *BlockchainMock) HashByHeight(height uint32) ([]byte, error) {
+func (b *BlockchainMock) HashByHeight(height uint32) (types.Hash, error) {
 	args := b.Called(height)
-	var hash []byte
-	if args.Get(0) != nil {
-		hash = args.Get(0).([]byte)
-	}
-	return hash, args.Error(1)
+	return args.Get(0).(types.Hash), args.Error(1)
 }
 
-func (b *BlockchainMock) HeaderByHash(hash []byte) (*types.Header, error) {
+func (b *BlockchainMock) HeaderByHash(hash types.Hash) (*types.Header, error) {
 	args := b.Called(hash)
 	var header *types.Header
 	if args.Get(0) != nil {
@@ -236,7 +232,7 @@ func (b *BlockchainMock) HeaderByHeight(height uint32) (*types.Header, error) {
 	return header, args.Error(1)
 }
 
-func (b *BlockchainMock) BlockByHash(hash []byte) (*types.Block, error) {
+func (b *BlockchainMock) BlockByHash(hash types.Hash) (*types.Block, error) {
 	args := b.Called(hash)
 	var block *types.Block
 	if args.Get(0) != nil {
@@ -258,21 +254,21 @@ type FinderMock struct {
 	mock.Mock
 }
 
-func (f *FinderMock) Add(hash []byte, parent []byte) error {
+func (f *FinderMock) Add(hash types.Hash, parent types.Hash) error {
 	args := f.Called(hash, parent)
 	return args.Error(0)
 }
 
-func (f *FinderMock) Has(hash []byte) bool {
+func (f *FinderMock) Has(hash types.Hash) bool {
 	args := f.Called(hash)
 	return args.Bool(0)
 }
 
-func (f *FinderMock) Path() [][]byte {
+func (f *FinderMock) Path() []types.Hash {
 	args := f.Called()
-	var path [][]byte
+	var path []types.Hash
 	if args.Get(0) != nil {
-		path = args.Get(0).([][]byte)
+		path = args.Get(0).([]types.Hash)
 	}
 	return path
 }

--- a/node/node.go
+++ b/node/node.go
@@ -119,5 +119,5 @@ func (n *simpleNode) Entity(entity Entity) {
 	go handleEntity(n.log, n.wg, n.net, n.peers, n.pool, entity)
 }
 
-func (n *simpleNode) Collect(path [][]byte) {
+func (n *simpleNode) Collect(path []types.Hash) {
 }

--- a/node/statePeers.go
+++ b/node/statePeers.go
@@ -34,13 +34,13 @@ type peerManager interface {
 type simplePeers struct {
 	sync.Mutex
 	actives map[string]bool
-	tags    map[string][]string
+	tags    map[types.Hash][]string
 }
 
 func newPeers() *simplePeers {
 	return &simplePeers{
 		actives: make(map[string]bool),
-		tags:    make(map[string][]string),
+		tags:    make(map[types.Hash][]string),
 	}
 }
 
@@ -74,12 +74,12 @@ func (s *simplePeers) Tag(address string, hash types.Hash) {
 	s.Lock()
 	defer s.Unlock()
 
-	s.tags[string(hash[:])] = append(s.tags[string(hash[:])], address)
+	s.tags[hash] = append(s.tags[hash], address)
 }
 
 func (s *simplePeers) Tags(hash types.Hash) []string {
 	s.Lock()
 	defer s.Unlock()
 
-	return s.tags[string(hash[:])]
+	return s.tags[hash]
 }

--- a/node/statePeers.go
+++ b/node/statePeers.go
@@ -17,14 +17,18 @@
 
 package node
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/alvalor/alvalor-go/types"
+)
 
 type peerManager interface {
 	Active(address string)
 	Inactive(address string)
 	Actives() []string
-	Tag(address string, id []byte)
-	Tags(id []byte) []string
+	Tag(address string, hash types.Hash)
+	Tags(hash types.Hash) []string
 }
 
 type simplePeers struct {
@@ -66,16 +70,16 @@ func (s *simplePeers) Actives() []string {
 	return actives
 }
 
-func (s *simplePeers) Tag(address string, id []byte) {
+func (s *simplePeers) Tag(address string, hash types.Hash) {
 	s.Lock()
 	defer s.Unlock()
 
-	s.tags[string(id)] = append(s.tags[string(id)], address)
+	s.tags[string(hash[:])] = append(s.tags[string(hash[:])], address)
 }
 
-func (s *simplePeers) Tags(id []byte) []string {
+func (s *simplePeers) Tags(hash types.Hash) []string {
 	s.Lock()
 	defer s.Unlock()
 
-	return s.tags[string(id)]
+	return s.tags[string(hash[:])]
 }

--- a/node/statePeers_test.go
+++ b/node/statePeers_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/alvalor/alvalor-go/types"
 )
 
 func TestNewPeers(t *testing.T) {
@@ -82,37 +84,37 @@ func TestPeersActives(t *testing.T) {
 }
 
 func TestPeersTag(t *testing.T) {
-	id1 := []byte{1, 2, 3, 4}
-	id2 := []byte{5, 6, 7, 8}
+	id1 := [32]byte{1, 2, 3, 4}
+	id2 := [32]byte{5, 6, 7, 8}
 	address1 := "192.0.2.100:1337"
 	address2 := "192.0.2.200:1337"
-	peers := &simplePeers{tags: make(map[string][]string)}
+	peers := &simplePeers{tags: make(map[types.Hash][]string)}
 
 	peers.Tag(address1, id1)
-	if assert.Len(t, peers.tags[string(id1)], 1) {
-		assert.Contains(t, peers.tags[string(id1)], address1)
+	if assert.Len(t, peers.tags[id1], 1) {
+		assert.Contains(t, peers.tags[id1], address1)
 	}
 
-	assert.Empty(t, peers.tags[string(id2)])
+	assert.Empty(t, peers.tags[id2])
 
 	peers.Tag(address1, id2)
-	if assert.Len(t, peers.tags[string(id2)], 1) {
-		assert.Contains(t, peers.tags[string(id2)], address1)
+	if assert.Len(t, peers.tags[id2], 1) {
+		assert.Contains(t, peers.tags[id2], address1)
 	}
 
 	peers.Tag(address2, id1)
-	if assert.Len(t, peers.tags[string(id1)], 2) {
-		assert.Contains(t, peers.tags[string(id1)], address2)
+	if assert.Len(t, peers.tags[id1], 2) {
+		assert.Contains(t, peers.tags[id1], address2)
 	}
 }
 
 func TestPeersTags(t *testing.T) {
-	id := []byte{1, 2, 3, 4}
+	id := [32]byte{1, 2, 3, 4}
 	address1 := "192.0.2.100:1337"
 	address2 := "192.0.2.200:1337"
-	peers := &simplePeers{tags: make(map[string][]string)}
+	peers := &simplePeers{tags: make(map[types.Hash][]string)}
 
-	peers.tags[string(id)] = []string{address1, address2}
+	peers.tags[id] = []string{address1, address2}
 	tags := peers.Tags(id)
 	assert.ElementsMatch(t, []string{address1, address2}, tags)
 }

--- a/node/statePool_test.go
+++ b/node/statePool_test.go
@@ -52,9 +52,9 @@ func TestPoolAdd(t *testing.T) {
 	store.On("Put", tx3.Hash(), mock.Anything).Return(errors.New("could not put"))
 
 	pool := simplePool{
-		codec: codec,
-		store: store,
-		ids:   make(map[string]struct{}),
+		codec:  codec,
+		store:  store,
+		hashes: make(map[types.Hash]struct{}),
 	}
 
 	err := pool.Add(tx1)
@@ -69,12 +69,12 @@ func TestPoolAdd(t *testing.T) {
 
 func TestPoolGet(t *testing.T) {
 
-	id1 := []byte{1, 2, 3, 4}
-	id2 := []byte{4, 5, 6, 7}
-	id3 := []byte{8, 9, 0, 1}
+	id1 := [32]byte{1, 2, 3, 4}
+	id2 := [32]byte{4, 5, 6, 7}
+	id3 := [32]byte{8, 9, 0, 1}
 
-	tx1 := &types.Transaction{Data: id1}
-	tx3 := &types.Transaction{Data: id3}
+	tx1 := &types.Transaction{Data: id1[:]}
+	tx3 := &types.Transaction{Data: id3[:]}
 
 	store := &StoreMock{}
 	store.On("Get", id1).Return(id1, nil)
@@ -102,16 +102,16 @@ func TestPoolGet(t *testing.T) {
 
 func TestPoolRemove(t *testing.T) {
 
-	id1 := []byte{1, 2, 3, 4}
-	id2 := []byte{4, 5, 6, 7}
+	id1 := [32]byte{1, 2, 3, 4}
+	id2 := [32]byte{4, 5, 6, 7}
 
 	store := &StoreMock{}
 	store.On("Del", id1).Return(nil)
 	store.On("Del", id2).Return(errors.New("could not del"))
 
 	pool := simplePool{
-		store: store,
-		ids:   make(map[string]struct{}),
+		store:  store,
+		hashes: make(map[types.Hash]struct{}),
 	}
 
 	err := pool.Remove(id1)
@@ -123,13 +123,13 @@ func TestPoolRemove(t *testing.T) {
 
 func TestPoolKnown(t *testing.T) {
 
-	id1 := []byte{1, 2, 3, 4}
-	id2 := []byte{5, 6, 7, 8}
+	id1 := [32]byte{1, 2, 3, 4}
+	id2 := [32]byte{5, 6, 7, 8}
 
 	pool := simplePool{
-		ids: make(map[string]struct{}),
+		hashes: make(map[types.Hash]struct{}),
 	}
-	pool.ids[string(id1)] = struct{}{}
+	pool.hashes[id1] = struct{}{}
 
 	ok := pool.Known(id1)
 	assert.True(t, ok)

--- a/store/store.go
+++ b/store/store.go
@@ -20,6 +20,7 @@ package store
 import (
 	"bytes"
 
+	"github.com/alvalor/alvalor-go/types"
 	"github.com/pkg/errors"
 )
 
@@ -41,14 +42,14 @@ func New(kv KV, codec Codec, prefix string) *Store {
 }
 
 // Save will put a new entity into the store.
-func (s *Store) Save(hash []byte, entity interface{}) error {
+func (s *Store) Save(hash types.Hash, entity interface{}) error {
 	buf := &bytes.Buffer{}
 	err := s.codec.Encode(buf, entity)
 	if err != nil {
 		return errors.Wrap(err, "could not encode entity")
 	}
 	data := buf.Bytes()
-	key := append(s.prefix, hash...)
+	key := append(s.prefix, hash[:]...)
 	err = s.kv.Put(key, data)
 	if err != nil {
 		return errors.Wrap(err, "could not put entity data")
@@ -57,8 +58,8 @@ func (s *Store) Save(hash []byte, entity interface{}) error {
 }
 
 // Retrieve will retrieve an entity from the store.
-func (s *Store) Retrieve(hash []byte) (interface{}, error) {
-	key := append(s.prefix, hash...)
+func (s *Store) Retrieve(hash types.Hash) (interface{}, error) {
+	key := append(s.prefix, hash[:]...)
 	data, err := s.kv.Get(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get entity data")

--- a/store/store.go
+++ b/store/store.go
@@ -20,8 +20,9 @@ package store
 import (
 	"bytes"
 
-	"github.com/alvalor/alvalor-go/types"
 	"github.com/pkg/errors"
+
+	"github.com/alvalor/alvalor-go/types"
 )
 
 // Store represents a store to store entities by unique ID.

--- a/types/hash.go
+++ b/types/hash.go
@@ -15,12 +15,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
 
-package blockchain
+package types
 
-import "github.com/alvalor/alvalor-go/types"
+// ZeroHash represents a hash of all zeroes.
+var ZeroHash = [32]byte{0}
 
-// Store represents an entity database.
-type Store interface {
-	Save(hash types.Hash, entity interface{}) error
-	Retrieve(hash types.Hash) (interface{}, error)
-}
+// Hash represents the 256-bit hashes used as IDs for our entities.
+type Hash [32]byte

--- a/types/header.go
+++ b/types/header.go
@@ -26,34 +26,35 @@ import (
 
 // Header represents the header data of a block that will be hashed.
 type Header struct {
-	Parent []byte
-	State  []byte
-	Delta  []byte
-	Miner  []byte
-	Target []byte
-	Time   time.Time
+	Parent Hash
+	State  Hash
+	Delta  Hash
+	Miner  Hash
+	Target uint64
 	Nonce  uint64
-	hash   []byte
+	Time   time.Time
+	hash   Hash
 }
 
 // Hash returns the unique hash of header.
-func (hdr Header) Hash() []byte {
-	if hdr.hash == nil {
-		hdr.hash = hdr.calc()
+func (hdr Header) Hash() Hash {
+	if hdr.hash == ZeroHash {
+		hash := hdr.calc()
+		copy(hdr.hash[:], hash)
 	}
 	return hdr.hash
 }
 
 func (hdr Header) calc() []byte {
 	h, _ := blake2s.New256(nil)
-	_, _ = h.Write(hdr.Parent)
-	_, _ = h.Write(hdr.State)
-	_, _ = h.Write(hdr.Delta)
-	_, _ = h.Write(hdr.Miner)
-	_, _ = h.Write(hdr.Target)
-	data := make([]byte, 16)
-	binary.LittleEndian.PutUint64(data[:8], uint64(hdr.Time.Unix()))
-	binary.LittleEndian.PutUint64(data[8:], hdr.Nonce)
+	_, _ = h.Write(hdr.Parent[:])
+	_, _ = h.Write(hdr.State[:])
+	_, _ = h.Write(hdr.Delta[:])
+	_, _ = h.Write(hdr.Miner[:])
+	data := make([]byte, 24)
+	binary.LittleEndian.PutUint64(data[:8], hdr.Target)
+	binary.LittleEndian.PutUint64(data[8:16], uint64(hdr.Time.Unix()))
+	binary.LittleEndian.PutUint64(data[16:], hdr.Nonce)
 	_, _ = h.Write(data)
 	return h.Sum(nil)
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -30,13 +30,14 @@ type Transaction struct {
 	Data       []byte
 	Nonce      uint64
 	Signatures [][]byte
-	hash       []byte
+	hash       Hash
 }
 
 // Hash returns the unique hash of the transaction.
-func (tx *Transaction) Hash() []byte {
-	if tx.hash == nil {
-		tx.hash = tx.calc()
+func (tx *Transaction) Hash() Hash {
+	if tx.hash == ZeroHash {
+		hash := tx.calc()
+		copy(tx.hash[:], hash)
 	}
 	return tx.hash
 }


### PR DESCRIPTION
This PR changes all functions working on hashes of blocks or transactions to use a fixed-size 32-byte array instead of the byte slice. This will make a lot of the functions more type-safe, though I'm not sure how it affects performance as we will have more pass-by-value semantics for 32-byte values.