### PR TITLE
Fix encoding of hash arrays

### DIFF
--- a/codec/inventory.capnp
+++ b/codec/inventory.capnp
@@ -21,5 +21,5 @@ $Go.import("codec");
 
 @0x9fd0f7eb12926b5d;
 struct Inventory {
-  ids @0: List(Data);
+  hashes @0: List(Data);
 }

--- a/codec/inventory.capnp.go
+++ b/codec/inventory.capnp.go
@@ -33,23 +33,23 @@ func (s Inventory) String() string {
 	return str
 }
 
-func (s Inventory) Ids() (capnp.DataList, error) {
+func (s Inventory) Hashes() (capnp.DataList, error) {
 	p, err := s.Struct.Ptr(0)
 	return capnp.DataList{List: p.List()}, err
 }
 
-func (s Inventory) HasIds() bool {
+func (s Inventory) HasHashes() bool {
 	p, err := s.Struct.Ptr(0)
 	return p.IsValid() || err != nil
 }
 
-func (s Inventory) SetIds(v capnp.DataList) error {
+func (s Inventory) SetHashes(v capnp.DataList) error {
 	return s.Struct.SetPtr(0, v.List.ToPtr())
 }
 
-// NewIds sets the ids field to a newly
+// NewHashes sets the hashes field to a newly
 // allocated capnp.DataList, preferring placement in s's segment.
-func (s Inventory) NewIds(n int32) (capnp.DataList, error) {
+func (s Inventory) NewHashes(n int32) (capnp.DataList, error) {
 	l, err := capnp.NewDataList(s.Struct.Segment(), n)
 	if err != nil {
 		return capnp.DataList{}, err
@@ -90,9 +90,9 @@ const schema_9fd0f7eb12926b5d = "x\xda2pct`2d\xf5\xe7d`\x08\xcca" +
 	"\x97\xe5\x92\xf0L\x16\x10k*\x8b=\xc3\x7f\x06\xf9\xff" +
 	"\x99ye\xa9y%\xf9EL\x95z\xc9\x89\x05y\x05" +
 	"V\x9eP\x01\xc6\xca\x00F\xc6@\x16f\x16\x06\x06\x16" +
-	"F\x06\x06A^%\x06\x86@\x0ef\xc6@\x15&F" +
-	"\xf6\xcc\x94bF>\x06\xc6\x00fFF^\x06&\x10" +
-	"\x13\x10\x00\x00\xff\xff\xef\x07\x1f\xde"
+	"F\x06\x06A^+\x06\x86@\x0ef\xc6@\x15&F" +
+	"\xfb\x8c\xc4\xe2\x8c\xd4bF>\x06\xc6\x00fFF^" +
+	"\x06&\x10\x13\x10\x00\x00\xff\xffi\xf0!j"
 
 func init() {
 	schemas.Register(schema_9fd0f7eb12926b5d,

--- a/codec/inventory.go
+++ b/codec/inventory.go
@@ -22,6 +22,7 @@ import (
 	capnp "zombiezen.com/go/capnproto2"
 
 	"github.com/alvalor/alvalor-go/node"
+	"github.com/alvalor/alvalor-go/types"
 )
 
 type initInventory func() (Inventory, error)
@@ -39,14 +40,14 @@ func encodeInventory(seg *capnp.Segment, create initInventory, e *node.Inventory
 	if err != nil {
 		return Inventory{}, errors.Wrap(err, "could not create inventory")
 	}
-	ids, err := inventory.NewIds(int32(len(e.IDs)))
+	hashes, err := inventory.NewHashes(int32(len(e.Hashes)))
 	if err != nil {
-		return Inventory{}, errors.Wrap(err, "could not create ID list")
+		return Inventory{}, errors.Wrap(err, "could not create hash list")
 	}
-	for i, id := range e.IDs {
-		err = ids.Set(i, id)
+	for i, hash := range e.Hashes {
+		err = hashes.Set(i, hash[:])
 		if err != nil {
-			return Inventory{}, errors.Wrap(err, "could not set ID")
+			return Inventory{}, errors.Wrap(err, "could not set hash")
 		}
 	}
 	return inventory, nil
@@ -57,19 +58,19 @@ func decodeInventory(read initInventory) (*node.Inventory, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read inventory")
 	}
-	ids, err := inventory.Ids()
+	hashes, err := inventory.Hashes()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read ID list")
+		return nil, errors.Wrap(err, "could not read hash list")
 	}
 	e := &node.Inventory{
-		IDs: make([][]byte, 0, ids.Len()),
+		Hashes: make([]types.Hash, hashes.Len()),
 	}
-	for i := 0; i < ids.Len(); i++ {
-		id, err := ids.At(i)
+	for i := 0; i < hashes.Len(); i++ {
+		hash, err := hashes.At(i)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not get ID")
+			return nil, errors.Wrap(err, "could not get hash")
 		}
-		e.IDs = append(e.IDs, id)
+		copy(e.Hashes[i][:], hash)
 	}
 	return e, nil
 }

--- a/codec/inventory_test.go
+++ b/codec/inventory_test.go
@@ -24,12 +24,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alvalor/alvalor-go/node"
+	"github.com/alvalor/alvalor-go/types"
 )
 
 func TestInventory(t *testing.T) {
 	proto := &Proto{}
 	inventory := &node.Inventory{
-		IDs: [][]byte{
+		Hashes: []types.Hash{
 			{11, 12, 13},
 			{21, 22, 23},
 			{31, 32, 33},

--- a/codec/request.capnp
+++ b/codec/request.capnp
@@ -21,5 +21,5 @@ $Go.import("codec");
 
 @0x88b5d31dcdf19e4d;
 struct Request {
-  ids @0: List(Data);
+  hashes @0: List(Data);
 }

--- a/codec/request.capnp.go
+++ b/codec/request.capnp.go
@@ -33,23 +33,23 @@ func (s Request) String() string {
 	return str
 }
 
-func (s Request) Ids() (capnp.DataList, error) {
+func (s Request) Hashes() (capnp.DataList, error) {
 	p, err := s.Struct.Ptr(0)
 	return capnp.DataList{List: p.List()}, err
 }
 
-func (s Request) HasIds() bool {
+func (s Request) HasHashes() bool {
 	p, err := s.Struct.Ptr(0)
 	return p.IsValid() || err != nil
 }
 
-func (s Request) SetIds(v capnp.DataList) error {
+func (s Request) SetHashes(v capnp.DataList) error {
 	return s.Struct.SetPtr(0, v.List.ToPtr())
 }
 
-// NewIds sets the ids field to a newly
+// NewHashes sets the hashes field to a newly
 // allocated capnp.DataList, preferring placement in s's segment.
-func (s Request) NewIds(n int32) (capnp.DataList, error) {
+func (s Request) NewHashes(n int32) (capnp.DataList, error) {
 	l, err := capnp.NewDataList(s.Struct.Segment(), n)
 	if err != nil {
 		return capnp.DataList{}, err
@@ -90,9 +90,9 @@ const schema_88b5d31dcdf19e4d = "x\xda2pet`2d\xf5\xe7d`\x08\xcca" +
 	"/\xcb&\xe1\xa9, \xd6D\x16{\x86\xff\x0c\xf2\xff" +
 	"\x8bR\x0bKS\x8bK\xf4\x18\x93\x13\x0b\xf2\x0a\xac\x82" +
 	"R\xe5\xc1\xfc\x00F\xc6@\x16f\x16\x06\x06\x16F\x06" +
-	"\x06A^%\x06\x86@\x0ef\xc6@\x15&F\xf6\xcc" +
-	"\x94bF>\x06\xc6\x00fFF^\x06&\x10\x13\x10" +
-	"\x00\x00\xff\xffI\xaf\x1ee"
+	"\x06A^+\x06\x86@\x0ef\xc6@\x15&F\xfb\x8c" +
+	"\xc4\xe2\x8c\xd4bF>\x06\xc6\x00fFF^\x06&" +
+	"\x10\x13\x10\x00\x00\xff\xff\xc0\x1e\x1f\xf1"
 
 func init() {
 	schemas.Register(schema_88b5d31dcdf19e4d,

--- a/codec/request_test.go
+++ b/codec/request_test.go
@@ -24,12 +24,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alvalor/alvalor-go/node"
+	"github.com/alvalor/alvalor-go/types"
 )
 
 func TestRequest(t *testing.T) {
 	proto := &Proto{}
 	request := &node.Request{
-		IDs: [][]byte{
+		Hashes: []types.Hash{
 			{11, 12, 13},
 			{21, 22, 23},
 			{31, 32, 33},

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -17,34 +17,38 @@
 
 package finder
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/alvalor/alvalor-go/types"
+)
 
 // Finder will manage a tree of block hashes to identify the longest valid path.
 type Finder struct {
 	root   *node
-	lookup map[string]*node
+	lookup map[types.Hash]*node
 }
 
 // New will create a new manager for paths.
-func New(root []byte) *Finder {
+func New(root types.Hash) *Finder {
 	n := &node{
 		hash: root,
 	}
 	f := &Finder{
 		root:   n,
-		lookup: make(map[string]*node),
+		lookup: make(map[types.Hash]*node),
 	}
-	f.lookup[string(root)] = n
+	f.lookup[root] = n
 	return f
 }
 
 // Add will add a new hash with the given parent to the path finding.
-func (f *Finder) Add(hash []byte, parent []byte) error {
-	_, ok := f.lookup[string(hash)]
+func (f *Finder) Add(hash types.Hash, parent types.Hash) error {
+	_, ok := f.lookup[hash]
 	if ok {
 		return errors.New("hash already known")
 	}
-	par, ok := f.lookup[string(parent)]
+	par, ok := f.lookup[parent]
 	if !ok {
 		return errors.New("parent not known")
 	}
@@ -53,18 +57,18 @@ func (f *Finder) Add(hash []byte, parent []byte) error {
 		parent: par,
 	}
 	par.children = append(par.children, n)
-	f.lookup[string(hash)] = n
+	f.lookup[hash] = n
 	return nil
 }
 
 // Has will check whether the given hash is known.
-func (f *Finder) Has(hash []byte) bool {
-	_, ok := f.lookup[string(hash)]
+func (f *Finder) Has(hash types.Hash) bool {
+	_, ok := f.lookup[hash]
 	return ok
 }
 
 // Path will return the hashes along the longest path.
-func (f *Finder) Path() [][]byte {
+func (f *Finder) Path() []types.Hash {
 	// TODO: ensure the path remains stable even when their is a new equal length path
 	return path(f.root)
 }

--- a/finder/node.go
+++ b/finder/node.go
@@ -17,8 +17,10 @@
 
 package finder
 
+import "github.com/alvalor/alvalor-go/types"
+
 type node struct {
-	hash     []byte
+	hash     types.Hash
 	parent   *node
 	children []*node
 }

--- a/finder/path.go
+++ b/finder/path.go
@@ -17,11 +17,13 @@
 
 package finder
 
-func path(n *node) [][]byte {
+import "github.com/alvalor/alvalor-go/types"
+
+func path(n *node) []types.Hash {
 	if len(n.children) == 0 {
-		return [][]byte{n.hash}
+		return []types.Hash{n.hash}
 	}
-	var best [][]byte
+	var best []types.Hash
 	for _, child := range n.children {
 		p := path(child)
 		if len(p) <= len(best) {
@@ -29,5 +31,5 @@ func path(n *node) [][]byte {
 		}
 		best = p
 	}
-	return append([][]byte{n.hash}, best...)
+	return append([]types.Hash{n.hash}, best...)
 }


### PR DESCRIPTION
This PR fixes the encoding of messages that was broken when we migrated ID hashes from byte slices to fixed-size 32-byte arrays.