### PR TITLE
Update zerolog repository & uuid version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,8 +15,9 @@
 
 [[projects]]
   name = "github.com/awishformore/zerolog"
-  packages = [".","internal/json"]
-  revision = "425d4d7f88048d4652f4352c42f4078496fa5c54"
+  packages = ["."]
+  revision = "56a970de510213e50dbaa39ad73ac07c9ec75606"
+  version = "v1.5.0"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -85,10 +86,16 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/rs/zerolog"
+  packages = [".","internal/json"]
+  revision = "1c575db92819e737bf5f8751e6cc90d2ccd273e1"
+
+[[projects]]
+  branch = "master"
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
+  revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
 
 [[projects]]
   name = "github.com/spaolacci/murmur3"
@@ -142,19 +149,19 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["blake2s","ed25519","ed25519/internal/edwards25519","pbkdf2","sha3"]
-  revision = "c4a91bd4f524f10d064139674cf55852e055ad01"
+  revision = "21652f85b0fdddb6c2b6b77a5beca5c5a908174a"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","internal/timeseries","trace"]
-  revision = "892bf7b0c6e2f93b51166bf3882e50277fa5afc6"
+  revision = "e0c57d8f86c17f0724497efcb3bc617e82834821"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "8c0ece68c28377f4c326d85b94f8df0dace46f80"
+  revision = "cc7307a45468e49eaf2997c890f14aa03a26917b"
 
 [[projects]]
   name = "zombiezen.com/go/capnproto2"
@@ -165,6 +172,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4489f27794d5de7877fa4e4a100e29e0d243e5d13ac9ef868c20da7b7682c4f7"
+  inputs-digest = "6c028e783efcac1b1aa157abb0a52e5b741b95fb4f77c7994a61b96487042790"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,8 @@
   name = "github.com/andreburgaud/crypt2go"
 
 [[constraint]]
-  name = "github.com/awishformore/zerolog"
-  revision = "425d4d7f88048d4652f4352c42f4078496fa5c54"
+  branch = "master"
+  name = "github.com/rs/zerolog"
 
 [[constraint]]
   name = "github.com/dgraph-io/badger"
@@ -50,8 +50,8 @@
   version = "0.8.0"
 
 [[constraint]]
+  branch = "master"
   name = "github.com/satori/go.uuid"
-  version = "1.2.0"
 
 [[constraint]]
   name = "github.com/spf13/pflag"

--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/awishformore/zerolog"
 	"github.com/dgraph-io/badger"
+	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 
 	"github.com/alvalor/alvalor-go/blockchain"

--- a/network/acceptor.go
+++ b/network/acceptor.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleAccepting(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, pending pendingManager, peers peerManager, rep reputationManager, book addressManager, events eventManager, conn net.Conn) {

--- a/network/connector.go
+++ b/network/connector.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"sync"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleConnecting(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, pending pendingManager, peers peerManager, rep reputationManager, book addressManager, dialer dialWrapper, events eventManager, address string) {

--- a/network/dialer.go
+++ b/network/dialer.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleDialing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager, pending pendingManager, book addressManager, rep reputationManager, handlers handlerManager, stop <-chan struct{}) {

--- a/network/discoverer.go
+++ b/network/discoverer.go
@@ -20,7 +20,7 @@ package network
 import (
 	"sync"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleDiscovering(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager) {

--- a/network/dropper.go
+++ b/network/dropper.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleDropping(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager, stop <-chan struct{}) {

--- a/network/listener.go
+++ b/network/listener.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleListening(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, handlers handlerManager, listener listenWrapper, stop <-chan struct{}) {

--- a/network/network.go
+++ b/network/network.go
@@ -25,7 +25,7 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -85,7 +85,7 @@ func New(log zerolog.Logger, codec Codec, subscriber chan<- interface{}, options
 		minPeers:   3,
 		maxPeers:   10,
 		maxPending: 16,
-		nonce:      uuid.NewV4().Bytes(),
+		nonce:      uuid.Must(uuid.NewV4()).Bytes(),
 		interval:   time.Second,
 		codec:      codec,
 		bufferSize: 16,

--- a/network/processor.go
+++ b/network/processor.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleProcessing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, book addressManager, events eventManager, address string, input <-chan interface{}, output chan<- interface{}) {

--- a/network/receiver.go
+++ b/network/receiver.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleReceiving(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, rep reputationManager, peers peerManager, address string, r io.Reader, input chan<- interface{}) {

--- a/network/sender.go
+++ b/network/sender.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleSending(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, rep reputationManager, events eventManager, address string, output <-chan interface{}, w io.Writer) {

--- a/network/server.go
+++ b/network/server.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleServing(log zerolog.Logger, wg *sync.WaitGroup, cfg *Config, peers peerManager, handlers handlerManager, stop <-chan struct{}) {

--- a/node/handleEntity.go
+++ b/node/handleEntity.go
@@ -20,7 +20,7 @@ package node
 import (
 	"sync"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 
 	"github.com/alvalor/alvalor-go/types"
 )

--- a/node/handleEvent.go
+++ b/node/handleEvent.go
@@ -20,7 +20,7 @@ package node
 import (
 	"sync"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 
 	"github.com/alvalor/alvalor-go/network"
 )

--- a/node/handleInput.go
+++ b/node/handleInput.go
@@ -20,7 +20,7 @@ package node
 import (
 	"sync"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 )
 
 func handleInput(log zerolog.Logger, wg *sync.WaitGroup, handlers Handlers, subscription <-chan interface{}) {

--- a/node/handleMessage.go
+++ b/node/handleMessage.go
@@ -20,7 +20,7 @@ package node
 import (
 	"sync"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 
 	"github.com/alvalor/alvalor-go/types"
 )

--- a/node/node.go
+++ b/node/node.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 
 	"github.com/alvalor/alvalor-go/trie"
 	"github.com/alvalor/alvalor-go/types"


### PR DESCRIPTION
I updated the dependency of zerolog back to the original master, which merged my changes to include a `Hex(...)` function. I also updated `uuid` to master instead of a tag, as it breaks the API and this is more future proof.