### PR TITLE
Fixed zerolog dependencies to point to github.com/rs/zerolog

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,12 +14,6 @@
   revision = "18fdff33d8fa6779a6eb859c3fbe0d330b340da2"
 
 [[projects]]
-  name = "github.com/awishformore/zerolog"
-  packages = ["."]
-  revision = "56a970de510213e50dbaa39ad73ac07c9ec75606"
-  version = "v1.5.0"
-
-[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -27,7 +21,14 @@
 
 [[projects]]
   name = "github.com/dgraph-io/badger"
-  packages = [".","options","protos","skl","table","y"]
+  packages = [
+    ".",
+    "options",
+    "protos",
+    "skl",
+    "table",
+    "y"
+  ]
   revision = "69611218c7078be6de16f4ea13fb256e701b6b73"
   version = "v1.3.0"
 
@@ -88,7 +89,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/rs/zerolog"
-  packages = [".","internal/json"]
+  packages = [
+    ".",
+    "internal/json"
+  ]
   revision = "1c575db92819e737bf5f8751e6cc90d2ccd273e1"
 
 [[projects]]
@@ -117,7 +121,12 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock","require","suite"]
+  packages = [
+    "assert",
+    "mock",
+    "require",
+    "suite"
+  ]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
@@ -148,13 +157,23 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["blake2s","ed25519","ed25519/internal/edwards25519","pbkdf2","sha3"]
+  packages = [
+    "blake2s",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "pbkdf2",
+    "sha3"
+  ]
   revision = "21652f85b0fdddb6c2b6b77a5beca5c5a908174a"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","internal/timeseries","trace"]
+  packages = [
+    "context",
+    "internal/timeseries",
+    "trace"
+  ]
   revision = "e0c57d8f86c17f0724497efcb3bc617e82834821"
 
 [[projects]]
@@ -165,13 +184,21 @@
 
 [[projects]]
   name = "zombiezen.com/go/capnproto2"
-  packages = [".","encoding/text","internal/nodemap","internal/packed","internal/schema","internal/strquote","schemas"]
+  packages = [
+    ".",
+    "encoding/text",
+    "internal/nodemap",
+    "internal/packed",
+    "internal/schema",
+    "internal/strquote",
+    "schemas"
+  ]
   revision = "243bfedb776812540b7e2fb8d4e5c19814ab1ed8"
   version = "v2.17.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6c028e783efcac1b1aa157abb0a52e5b741b95fb4f77c7994a61b96487042790"
+  inputs-digest = "0babc0ab6abb904d72c301f08d757ffc6394b6042f35d6fea78f523a34044426"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/network/acceptor_test.go
+++ b/network/acceptor_test.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/network/connector_test.go
+++ b/network/connector_test.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/network/dialer_test.go
+++ b/network/dialer_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )

--- a/network/discoverer_test.go
+++ b/network/discoverer_test.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )

--- a/network/dropper_test.go
+++ b/network/dropper_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )

--- a/network/listener_test.go
+++ b/network/listener_test.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )

--- a/network/processor_test.go
+++ b/network/processor_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/network/receiver_test.go
+++ b/network/receiver_test.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/network/sender_test.go
+++ b/network/sender_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/node/handleEntity_test.go
+++ b/node/handleEntity_test.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 

--- a/node/handleEvent_test.go
+++ b/node/handleEvent_test.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 

--- a/node/handleMessage_test.go
+++ b/node/handleMessage_test.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awishformore/zerolog"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 


### PR DESCRIPTION
Changing zerolog reference to point to rs/zerolog as awishformore/zerolog fork is deleted.