### PR TITLE
Fixed naming & race condition

### DIFF
--- a/node/eventManager.go
+++ b/node/eventManager.go
@@ -19,8 +19,9 @@ package node
 
 import (
 	"errors"
-	"github.com/alvalor/alvalor-go/types"
 	"time"
+
+	"github.com/alvalor/alvalor-go/types"
 )
 
 type eventManager interface {
@@ -28,12 +29,12 @@ type eventManager interface {
 }
 
 type simpleEventManager struct {
-	subscriber chan<- interface{}
+	stream chan<- interface{}
 }
 
 func (mgr *simpleEventManager) Transaction(hash types.Hash) error {
 	select {
-	case mgr.subscriber <- Transaction{hash: hash}:
+	case mgr.stream <- Transaction{hash: hash}:
 	case <-time.After(10 * time.Millisecond):
 		return errors.New("subscriber stalling")
 	}

--- a/node/handleEntity_test.go
+++ b/node/handleEntity_test.go
@@ -66,10 +66,12 @@ func (suite *EntitySuite) TestEntityTransaction() {
 	pool.On("Known", mock.Anything).Return(false)
 	pool.On("Add", mock.Anything).Return(nil)
 
+	events := &EventManagerMock{}
+
 	entity := &types.Transaction{}
 
 	// act
-	handleEntity(suite.log, suite.wg, net, peers, pool, entity)
+	handleEntity(suite.log, suite.wg, net, peers, pool, entity, events)
 
 	// assert
 	t := suite.T()

--- a/node/mocks_test.go
+++ b/node/mocks_test.go
@@ -272,3 +272,12 @@ func (f *FinderMock) Path() []types.Hash {
 	}
 	return path
 }
+
+type EventManagerMock struct {
+	mock.Mock
+}
+
+func (em *EventManagerMock) Transaction(hash types.Hash) error {
+	args := em.Called(hash)
+	return args.Error(0)
+}


### PR DESCRIPTION
I simplified the naming a bit for the subscriber stuff. Stream represents the internal events that are handled by the package itself. Subscribers represents external consumers who want to subscribe to the event stream as well.

I also removed one waitgroup add that was superfluous and would lead to synchronization issues.