### PR TITLE
Parallel transaction download

### DIFF
--- a/node/handleHeaders.go
+++ b/node/handleHeaders.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"github.com/Workiva/go-datastructures/queue"
+	"github.com/alvalor/alvalor-go/types"
+	"github.com/rs/zerolog"
+	"sync"
+	"time"
+)
+
+func handleHeaders(log zerolog.Logger, wg *sync.WaitGroup, net Network, receivers map[string]queue.Queue, stop <-chan struct{}) {
+	defer wg.Done()
+
+	log = log.With().Str("component", "headers").Logger()
+
+	ticker := time.NewTicker(time.Millisecond * 100)
+	for {
+		select {
+		case <-stop:
+			ticker.Stop()
+			return
+		case <-ticker.C:
+		}
+
+		for addr, queue := range receivers {
+			if queue.Len() > 0 {
+				msg, err := queue.Get(1)
+
+				if err != nil {
+					continue
+				}
+
+				if len(msg) == 0 {
+					continue
+				}
+
+				header := msg[0].(types.Header)
+
+				err = net.Send(addr, header)
+				if err != nil {
+					log.Error().Err(err).Msg("could not send header")
+					continue
+				}
+			}
+		}
+	}
+}

--- a/node/handleHeaders.go
+++ b/node/handleHeaders.go
@@ -25,7 +25,7 @@ import (
 	"time"
 )
 
-func handleHeaders(log zerolog.Logger, wg *sync.WaitGroup, net Network, receivers map[string]queue.Queue, stop <-chan struct{}) {
+func handleHeaders(log zerolog.Logger, wg *sync.WaitGroup, net Network, receivers map[string]*queue.Queue, stop <-chan struct{}) {
 	defer wg.Done()
 
 	log = log.With().Str("component", "headers").Logger()

--- a/node/handleMessage.go
+++ b/node/handleMessage.go
@@ -145,11 +145,7 @@ func handleMessage(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Bl
 
 		// send each header
 		for _, header := range headers {
-			err := net.Send(address, header)
-			if err != nil {
-				log.Error().Err(err).Msg("could not send header")
-				return
-			}
+			handlers.Header(address, header)
 		}
 
 		log.Debug().Msg("processed synchronization message")

--- a/node/handlers.go
+++ b/node/handlers.go
@@ -31,4 +31,5 @@ type Handlers interface {
 	Message(address string, message interface{})
 	Entity(entity Entity)
 	Collect(path []types.Hash)
+	Header(address string, header *types.Header)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -57,7 +57,7 @@ type simpleNode struct {
 	events          eventManager
 	stream          chan interface{}
 	subscribers     []subscriber
-	headerReceivers map[string]queue.Queue
+	headerReceivers map[string]*queue.Queue
 	stop            chan struct{}
 }
 
@@ -99,7 +99,7 @@ func New(log zerolog.Logger, net Network, chain Blockchain, finder Finder, codec
 
 	n.stop = make(chan struct{})
 
-	n.headerReceivers = make(map[string]queue.Queue)
+	n.headerReceivers = make(map[string]*queue.Queue)
 
 	// handle all input messages we get
 	n.Input(input)
@@ -182,7 +182,7 @@ func (n *simpleNode) Header(address string, header *types.Header) {
 		//TODO why there is a limit
 		q := queue.New(1024)
 		q.Put(header)
-		n.headerReceivers[address] = *q
+		n.headerReceivers[address] = q
 	}
 
 }

--- a/node/node.go
+++ b/node/node.go
@@ -100,6 +100,7 @@ func New(log zerolog.Logger, net Network, chain Blockchain, finder Finder, codec
 
 	n.stop = make(chan struct{})
 
+	// create map of queues where each key is an address of the header receiver
 	n.headerReceivers = make(map[string]*queue.Queue)
 	n.headerReceiversLock = sync.Mutex{}
 
@@ -183,7 +184,7 @@ func (n *simpleNode) Header(address string, header *types.Header) {
 }
 
 func (n *simpleNode) getQueue(address string) *queue.Queue {
-	n.headerReceiversLock.Unlock()
+	n.headerReceiversLock.Lock()
 	defer n.headerReceiversLock.Unlock()
 
 	if q, ok := n.headerReceivers[address]; ok {

--- a/node/node.go
+++ b/node/node.go
@@ -70,6 +70,7 @@ type subscriber struct {
 
 // New creates a new node to manage the Alvalor blockchain.
 func New(log zerolog.Logger, net Network, chain Blockchain, finder Finder, codec Codec, input <-chan interface{}) Node {
+
 	// initialize the node
 	n := &simpleNode{}
 
@@ -98,6 +99,7 @@ func New(log zerolog.Logger, net Network, chain Blockchain, finder Finder, codec
 	// create the subscriber channel
 	n.stream = make(chan interface{}, 128)
 
+	// create the channel for shutdown
 	n.stop = make(chan struct{})
 
 	// create map of queues where each key is an address of the header receiver


### PR DESCRIPTION
Creating this PR for the sake of discussion and feedback.

Basically, the approach is to use multiple queues for each address so that one peer doesn't prevent others from receiving headers. There is a separate routine inside handleHeaders which iterates every address queue, takes one item from the queue and moves to the next address. @awishformore please take a look.