### PR TITLE
Implement header exchange with pathfinding

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -112,12 +112,11 @@ func (bc *Blockchain) AddBlock(block *types.Block) error {
 	// save each transaction & collect their indices
 	indices := make([]byte, 0, len(block.Transactions)*32)
 	for _, tx := range block.Transactions {
-		err = bc.transactions.Save(tx.Hash(), tx)
+		err = bc.transactions.Save(tx.Hash, tx)
 		if err != nil {
 			return errors.Wrap(err, "could not store block transaction")
 		}
-		txHash := tx.Hash()
-		indices = append(indices, txHash[:]...)
+		indices = append(indices, tx.Hash[:]...)
 	}
 
 	// map the block hash to the transaction indices
@@ -207,6 +206,7 @@ func (bc *Blockchain) TransactionByHash(hash types.Hash) (*types.Transaction, er
 	if !ok {
 		return nil, errors.New("could not convert entity to transaction")
 	}
+	tx.Hash = tx.GetHash()
 	return tx, nil
 }
 

--- a/node/handleEntity_test.go
+++ b/node/handleEntity_test.go
@@ -53,6 +53,8 @@ func (suite *EntitySuite) TestEntityTransaction() {
 	address2 := "192.0.2.2:1337"
 	address3 := "192.0.2.3:1337"
 
+	entity := &types.Transaction{}
+
 	net := &NetworkMock{}
 	net.On("Send", address1, mock.Anything).Return(errors.New("could not send"))
 	net.On("Send", address2, mock.Anything).Return(nil)
@@ -67,8 +69,7 @@ func (suite *EntitySuite) TestEntityTransaction() {
 	pool.On("Add", mock.Anything).Return(nil)
 
 	events := &EventManagerMock{}
-
-	entity := &types.Transaction{}
+	events.On("Transaction", entity.Hash()).Return(nil)
 
 	// act
 	handleEntity(suite.log, suite.wg, net, peers, pool, entity, events)

--- a/node/handleEntity_test.go
+++ b/node/handleEntity_test.go
@@ -69,7 +69,7 @@ func (suite *EntitySuite) TestEntityTransaction() {
 	pool.On("Add", mock.Anything).Return(nil)
 
 	events := &EventManagerMock{}
-	events.On("Transaction", entity.Hash()).Return(nil)
+	events.On("Transaction", entity.Hash).Return(nil)
 
 	// act
 	handleEntity(suite.log, suite.wg, net, peers, pool, entity, events)

--- a/node/handleEvent.go
+++ b/node/handleEvent.go
@@ -37,8 +37,9 @@ func handleEvent(log zerolog.Logger, wg *sync.WaitGroup, net Network, finder pat
 
 	case network.Connected:
 
-		path, distance := finder.Longest()
 		peers.Active(e.Address)
+
+		path, distance := finder.Longest()
 		status := &Status{
 			Distance: distance,
 			Hash:     path[0],

--- a/node/handleEvent.go
+++ b/node/handleEvent.go
@@ -25,7 +25,7 @@ import (
 	"github.com/alvalor/alvalor-go/network"
 )
 
-func handleEvent(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Blockchain, peers peerManager, handlers Handlers, event interface{}) {
+func handleEvent(log zerolog.Logger, wg *sync.WaitGroup, net Network, finder pathfinder, chain Blockchain, peers peerManager, handlers Handlers, event interface{}) {
 	defer wg.Done()
 
 	// configure logger
@@ -36,10 +36,12 @@ func handleEvent(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Bloc
 	switch e := event.(type) {
 
 	case network.Connected:
+
+		path, distance := finder.Longest()
 		peers.Active(e.Address)
 		status := &Status{
-			Height: chain.Height(),
-			Hash:   chain.Header().Hash,
+			Distance: distance,
+			Hash:     path[0],
 		}
 		err := net.Send(e.Address, status)
 		if err != nil {

--- a/node/handleEvent.go
+++ b/node/handleEvent.go
@@ -25,7 +25,7 @@ import (
 	"github.com/alvalor/alvalor-go/network"
 )
 
-func handleEvent(log zerolog.Logger, wg *sync.WaitGroup, net Network, finder pathfinder, chain Blockchain, peers peerManager, handlers Handlers, event interface{}) {
+func handleEvent(log zerolog.Logger, wg *sync.WaitGroup, net Network, finder pathfinder, peers peerManager, handlers Handlers, event interface{}) {
 	defer wg.Done()
 
 	// configure logger

--- a/node/handleEvent_test.go
+++ b/node/handleEvent_test.go
@@ -53,8 +53,6 @@ func (suite *EventSuite) TestEventConnected() {
 	net := &NetworkMock{}
 	net.On("Send", mock.Anything, mock.Anything).Return(nil)
 
-	chain := &BlockchainMock{}
-
 	finder := &PathfinderMock{}
 
 	peers := &PeersMock{}
@@ -72,7 +70,7 @@ func (suite *EventSuite) TestEventConnected() {
 	event := network.Connected{Address: address}
 
 	// act
-	handleEvent(suite.log, suite.wg, net, finder, chain, peers, handlers, event)
+	handleEvent(suite.log, suite.wg, net, finder, peers, handlers, event)
 
 	// assert
 	t := suite.T()
@@ -87,8 +85,6 @@ func (suite *EventSuite) TestEventDisconnected() {
 
 	net := &NetworkMock{}
 	net.On("Send", mock.Anything, mock.Anything).Return(nil)
-
-	chain := &BlockchainMock{}
 
 	finder := &PathfinderMock{}
 
@@ -107,7 +103,7 @@ func (suite *EventSuite) TestEventDisconnected() {
 	event := network.Disconnected{Address: address}
 
 	// act
-	handleEvent(suite.log, suite.wg, net, finder, chain, peers, handlers, event)
+	handleEvent(suite.log, suite.wg, net, finder, peers, handlers, event)
 
 	// assert
 	t := suite.T()
@@ -123,8 +119,6 @@ func (suite *EventSuite) TestEventReceived() {
 
 	net := &NetworkMock{}
 	net.On("Send", mock.Anything, mock.Anything).Return(nil)
-
-	chain := &BlockchainMock{}
 
 	finder := &PathfinderMock{}
 
@@ -143,7 +137,7 @@ func (suite *EventSuite) TestEventReceived() {
 	event := network.Received{Address: address, Message: message}
 
 	// act
-	handleEvent(suite.log, suite.wg, net, finder, chain, peers, handlers, event)
+	handleEvent(suite.log, suite.wg, net, finder, peers, handlers, event)
 
 	// assert
 	t := suite.T()

--- a/node/handleEvent_test.go
+++ b/node/handleEvent_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alvalor/alvalor-go/network"
+	"github.com/alvalor/alvalor-go/types"
 )
 
 func TestEvent(t *testing.T) {
@@ -54,6 +55,7 @@ func (suite *EventSuite) TestEventConnected() {
 	net.On("Send", mock.Anything, mock.Anything).Return(nil)
 
 	finder := &PathfinderMock{}
+	finder.On("Longest").Return([]types.Hash{types.ZeroHash}, 0)
 
 	peers := &PeersMock{}
 	peers.On("Active", mock.Anything)

--- a/node/handleEvent_test.go
+++ b/node/handleEvent_test.go
@@ -55,6 +55,8 @@ func (suite *EventSuite) TestEventConnected() {
 
 	chain := &BlockchainMock{}
 
+	finder := &PathfinderMock{}
+
 	peers := &PeersMock{}
 	peers.On("Active", mock.Anything)
 	peers.On("Inactive", mock.Anything)
@@ -70,7 +72,7 @@ func (suite *EventSuite) TestEventConnected() {
 	event := network.Connected{Address: address}
 
 	// act
-	handleEvent(suite.log, suite.wg, net, chain, peers, handlers, event)
+	handleEvent(suite.log, suite.wg, net, finder, chain, peers, handlers, event)
 
 	// assert
 	t := suite.T()
@@ -88,6 +90,8 @@ func (suite *EventSuite) TestEventDisconnected() {
 
 	chain := &BlockchainMock{}
 
+	finder := &PathfinderMock{}
+
 	peers := &PeersMock{}
 	peers.On("Active", mock.Anything)
 	peers.On("Inactive", mock.Anything)
@@ -103,7 +107,7 @@ func (suite *EventSuite) TestEventDisconnected() {
 	event := network.Disconnected{Address: address}
 
 	// act
-	handleEvent(suite.log, suite.wg, net, chain, peers, handlers, event)
+	handleEvent(suite.log, suite.wg, net, finder, chain, peers, handlers, event)
 
 	// assert
 	t := suite.T()
@@ -122,6 +126,8 @@ func (suite *EventSuite) TestEventReceived() {
 
 	chain := &BlockchainMock{}
 
+	finder := &PathfinderMock{}
+
 	peers := &PeersMock{}
 	peers.On("Active", mock.Anything)
 	peers.On("Inactive", mock.Anything)
@@ -137,7 +143,7 @@ func (suite *EventSuite) TestEventReceived() {
 	event := network.Received{Address: address, Message: message}
 
 	// act
-	handleEvent(suite.log, suite.wg, net, chain, peers, handlers, event)
+	handleEvent(suite.log, suite.wg, net, finder, chain, peers, handlers, event)
 
 	// assert
 	t := suite.T()

--- a/node/handleMessage.go
+++ b/node/handleMessage.go
@@ -133,23 +133,16 @@ func handleMessage(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Bl
 		log = log.With().Str("msg_type", "header").Hex("hash", msg.Hash[:]).Hex("parent", msg.Parent[:]).Logger()
 
 		// check if we already stored the header
-		_, err := chain.HeaderByHash(msg.Hash)
-		if err == nil {
+		ok := finder.Knows(msg.Hash)
+		if ok {
 			log.Debug().Msg("header already known")
 			return
 		}
 
-		// check if we already process the header
-		ok := finder.Knows(msg.Hash)
-		if ok {
-			log.Debug().Msg("header already processing")
-			return
-		}
-
 		// add the header to the path finder
-		// TODO: add pool of pending headers with missing parents
+		err := finder.Add(msg)
 		if err != nil {
-			log.Error().Err(err).Msg("could not add header to path")
+			log.Error().Err(err).Msg("could not add header to pathfinder")
 			return
 		}
 

--- a/node/handleMessage.go
+++ b/node/handleMessage.go
@@ -155,12 +155,13 @@ func handleMessage(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Bl
 
 	case *types.Transaction:
 
-		hash := msg.Hash()
+		// initialize the transaction hash
+		msg.Hash = msg.GetHash()
 
-		log = log.With().Str("msg_type", "transaction").Hex("hash", hash[:]).Logger()
+		log = log.With().Str("msg_type", "transaction").Hex("hash", msg.Hash[:]).Logger()
 
 		// check if we already know the transaction
-		_, err := chain.TransactionByHash(msg.Hash())
+		_, err := chain.TransactionByHash(msg.Hash)
 		if err == nil {
 			log.Debug().Msg("transaction already known")
 			return
@@ -169,7 +170,7 @@ func handleMessage(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Bl
 		// TODO: validate the transaction
 
 		// tag the peer for having seen the transaction
-		peers.Tag(address, msg.Hash())
+		peers.Tag(address, msg.Hash)
 
 		// handle the transaction for our blockchain state & propagation
 		handlers.Entity(msg)
@@ -268,7 +269,7 @@ func handleMessage(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Bl
 			// TODO: validate transaction
 
 			// tag the peer for having seen the transaction
-			peers.Tag(address, tx.Hash())
+			peers.Tag(address, tx.Hash)
 
 			// handle the transaction for our blockchain state & propagation
 			handlers.Entity(tx)

--- a/node/handleMessage.go
+++ b/node/handleMessage.go
@@ -25,7 +25,7 @@ import (
 	"github.com/alvalor/alvalor-go/types"
 )
 
-func handleMessage(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Blockchain, finder pathManager, peers peerManager, pool poolManager, handlers Handlers, address string, message interface{}) {
+func handleMessage(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Blockchain, finder pathfinder, peers peerManager, pool poolManager, handlers Handlers, address string, message interface{}) {
 	defer wg.Done()
 
 	// configure logger

--- a/node/handleMessage_test.go
+++ b/node/handleMessage_test.go
@@ -52,6 +52,7 @@ func (suite *MessageSuite) TestMessageTransaction() {
 	address := "192.0.2.100:1337"
 
 	msg := &types.Transaction{}
+	msg.Hash = msg.GetHash()
 
 	net := &NetworkMock{}
 

--- a/node/handleMessage_test.go
+++ b/node/handleMessage_test.go
@@ -54,7 +54,7 @@ func (suite *MessageSuite) TestMessageTransaction() {
 
 	chain := &BlockchainMock{}
 
-	finder := &FinderMock{}
+	finder := &PathfinderMock{}
 
 	peers := &PeersMock{}
 	peers.On("Tag", mock.Anything, mock.Anything)

--- a/node/handleMessage_test.go
+++ b/node/handleMessage_test.go
@@ -56,7 +56,7 @@ func (suite *MessageSuite) TestMessageTransaction() {
 	net := &NetworkMock{}
 
 	chain := &BlockchainMock{}
-	chain.On("TransactionByHash", msg.Hash()).Return(nil, errors.New("not found"))
+	chain.On("TransactionByHash", msg.Hash).Return(nil, errors.New("not found"))
 
 	finder := &PathfinderMock{}
 
@@ -74,6 +74,6 @@ func (suite *MessageSuite) TestMessageTransaction() {
 	// assert
 	t := suite.T()
 
-	peers.AssertCalled(t, "Tag", address, msg.Hash())
+	peers.AssertCalled(t, "Tag", address, msg.Hash)
 	handlers.AssertCalled(t, "Entity", msg)
 }

--- a/node/handleMessage_test.go
+++ b/node/handleMessage_test.go
@@ -18,6 +18,7 @@
 package node
 
 import (
+	"errors"
 	"io/ioutil"
 	"sync"
 	"testing"
@@ -50,9 +51,12 @@ func (suite *MessageSuite) TestMessageTransaction() {
 	// arrange
 	address := "192.0.2.100:1337"
 
+	msg := &types.Transaction{}
+
 	net := &NetworkMock{}
 
 	chain := &BlockchainMock{}
+	chain.On("TransactionByHash", msg.Hash()).Return(nil, errors.New("not found"))
 
 	finder := &PathfinderMock{}
 
@@ -63,8 +67,6 @@ func (suite *MessageSuite) TestMessageTransaction() {
 
 	handlers := &HandlersMock{}
 	handlers.On("Entity", mock.Anything)
-
-	msg := &types.Transaction{}
 
 	// act
 	handleMessage(suite.log, suite.wg, net, chain, finder, peers, pool, handlers, address, msg)

--- a/node/handlers.go
+++ b/node/handlers.go
@@ -21,7 +21,6 @@ import "github.com/alvalor/alvalor-go/types"
 
 // Entity is any data structure that returns a unique ID.
 type Entity interface {
-	Hash() types.Hash
 }
 
 // Handlers describes the handlers we need to process everything.

--- a/node/messages.go
+++ b/node/messages.go
@@ -25,8 +25,8 @@ import (
 
 // Status message shares our top block height.
 type Status struct {
-	Height uint32
-	Hash   types.Hash
+	Distance uint64
+	Hash     types.Hash
 }
 
 // Sync requests headers we are missing.

--- a/node/mocks_test.go
+++ b/node/mocks_test.go
@@ -259,6 +259,15 @@ func (f *FinderMock) Add(header *types.Header) error {
 	return args.Error(0)
 }
 
+func (f *FinderMock) Header(hash types.Hash) (*types.Header, error) {
+	args := f.Called(hash)
+	var header *types.Header
+	if args.Get(0) != nil {
+		header = args.Get(0).(*types.Header)
+	}
+	return header, args.Error(0)
+}
+
 func (f *FinderMock) Knows(hash types.Hash) bool {
 	args := f.Called(hash)
 	return args.Bool(0)

--- a/node/mocks_test.go
+++ b/node/mocks_test.go
@@ -250,17 +250,17 @@ func (b *BlockchainMock) BlockByHeight(height uint32) (*types.Block, error) {
 	return block, args.Error(1)
 }
 
-type FinderMock struct {
+type PathfinderMock struct {
 	mock.Mock
 }
 
-func (f *FinderMock) Add(header *types.Header) error {
-	args := f.Called(header)
+func (p *PathfinderMock) Add(header *types.Header) error {
+	args := p.Called(header)
 	return args.Error(0)
 }
 
-func (f *FinderMock) Header(hash types.Hash) (*types.Header, error) {
-	args := f.Called(hash)
+func (p *PathfinderMock) Header(hash types.Hash) (*types.Header, error) {
+	args := p.Called(hash)
 	var header *types.Header
 	if args.Get(0) != nil {
 		header = args.Get(0).(*types.Header)
@@ -268,13 +268,13 @@ func (f *FinderMock) Header(hash types.Hash) (*types.Header, error) {
 	return header, args.Error(0)
 }
 
-func (f *FinderMock) Knows(hash types.Hash) bool {
-	args := f.Called(hash)
+func (p *PathfinderMock) Knows(hash types.Hash) bool {
+	args := p.Called(hash)
 	return args.Bool(0)
 }
 
-func (f *FinderMock) Longest() []types.Hash {
-	args := f.Called()
+func (p *PathfinderMock) Longest() []types.Hash {
+	args := p.Called()
 	var path []types.Hash
 	if args.Get(0) != nil {
 		path = args.Get(0).([]types.Hash)

--- a/node/mocks_test.go
+++ b/node/mocks_test.go
@@ -273,13 +273,13 @@ func (p *PathfinderMock) Knows(hash types.Hash) bool {
 	return args.Bool(0)
 }
 
-func (p *PathfinderMock) Longest() []types.Hash {
+func (p *PathfinderMock) Longest() ([]types.Hash, uint64) {
 	args := p.Called()
 	var path []types.Hash
 	if args.Get(0) != nil {
 		path = args.Get(0).([]types.Hash)
 	}
-	return path
+	return path, uint64(args.Int(1))
 }
 
 type EventManagerMock struct {

--- a/node/node.go
+++ b/node/node.go
@@ -130,7 +130,7 @@ func (n *simpleNode) Input(input <-chan interface{}) {
 
 func (n *simpleNode) Event(event interface{}) {
 	n.wg.Add(1)
-	go handleEvent(n.log, n.wg, n.net, n.finder, n.chain, n.peers, n, event)
+	go handleEvent(n.log, n.wg, n.net, n.finder, n.peers, n, event)
 }
 
 func (n *simpleNode) Message(address string, message interface{}) {

--- a/node/node.go
+++ b/node/node.go
@@ -130,7 +130,7 @@ func (n *simpleNode) Input(input <-chan interface{}) {
 
 func (n *simpleNode) Event(event interface{}) {
 	n.wg.Add(1)
-	go handleEvent(n.log, n.wg, n.net, n.chain, n.peers, n, event)
+	go handleEvent(n.log, n.wg, n.net, n.finder, n.chain, n.peers, n, event)
 }
 
 func (n *simpleNode) Message(address string, message interface{}) {

--- a/node/node.go
+++ b/node/node.go
@@ -50,7 +50,7 @@ type simpleNode struct {
 	wg          *sync.WaitGroup
 	net         Network
 	chain       Blockchain
-	path        pathManager
+	finder      pathfinder
 	peers       peerManager
 	pool        poolManager
 	events      eventManager
@@ -84,7 +84,7 @@ func New(log zerolog.Logger, net Network, chain Blockchain, codec Codec, input <
 
 	// initialize header path finder
 	root := chain.Header()
-	n.path = newSimplePaths(root)
+	n.finder = newSimplePathfinder(root)
 
 	// initialize peer state manager
 	peers := newPeers()
@@ -135,7 +135,7 @@ func (n *simpleNode) Event(event interface{}) {
 
 func (n *simpleNode) Message(address string, message interface{}) {
 	n.wg.Add(1)
-	go handleMessage(n.log, n.wg, n.net, n.chain, n.path, n.peers, n.pool, n, address, message)
+	go handleMessage(n.log, n.wg, n.net, n.chain, n.finder, n.peers, n.pool, n, address, message)
 }
 
 func (n *simpleNode) Entity(entity Entity) {

--- a/node/pathManager.go
+++ b/node/pathManager.go
@@ -25,6 +25,7 @@ import (
 
 type pathManager interface {
 	Add(header *types.Header) error
+	Header(hash types.Hash) (*types.Header, error)
 	Knows(hash types.Hash) bool
 	Longest() []types.Hash
 }
@@ -51,6 +52,15 @@ func newSimplePaths(root *types.Header) *simplePath {
 func (sp *simplePath) Knows(hash types.Hash) bool {
 	_, ok := sp.headers[hash]
 	return ok
+}
+
+// Header returns the given header.
+func (sp *simplePath) Header(hash types.Hash) (*types.Header, error) {
+	header, ok := sp.headers[hash]
+	if !ok {
+		return nil, errors.New("header not found")
+	}
+	return header, nil
 }
 
 // Add adds a new header to the graph.

--- a/node/pathfinder.go
+++ b/node/pathfinder.go
@@ -23,23 +23,23 @@ import (
 	"github.com/alvalor/alvalor-go/types"
 )
 
-type pathManager interface {
+type pathfinder interface {
 	Add(header *types.Header) error
 	Header(hash types.Hash) (*types.Header, error)
 	Knows(hash types.Hash) bool
 	Longest() []types.Hash
 }
 
-// simplePath is a path manager using topological sort of all added headers to find the longest path to the root.
-type simplePath struct {
+// simplePathfinder is a path manager using topological sort of all added headers to find the longest path to the root.
+type simplePathfinder struct {
 	root     types.Hash
 	headers  map[types.Hash]*types.Header
 	children map[types.Hash][]types.Hash
 }
 
-// newsimplePath creates a new simple path manager using the given header as root.
-func newSimplePaths(root *types.Header) *simplePath {
-	sp := &simplePath{
+// newSimplePathfinder creates a new simple path manager using the given header as root.
+func newSimplePathfinder(root *types.Header) *simplePathfinder {
+	sp := &simplePathfinder{
 		root:     root.Hash,
 		headers:  make(map[types.Hash]*types.Header),
 		children: make(map[types.Hash][]types.Hash),
@@ -49,13 +49,13 @@ func newSimplePaths(root *types.Header) *simplePath {
 }
 
 // Knows checks if the given hash is already known.
-func (sp *simplePath) Knows(hash types.Hash) bool {
+func (sp *simplePathfinder) Knows(hash types.Hash) bool {
 	_, ok := sp.headers[hash]
 	return ok
 }
 
 // Header returns the given header.
-func (sp *simplePath) Header(hash types.Hash) (*types.Header, error) {
+func (sp *simplePathfinder) Header(hash types.Hash) (*types.Header, error) {
 	header, ok := sp.headers[hash]
 	if !ok {
 		return nil, errors.New("header not found")
@@ -64,7 +64,7 @@ func (sp *simplePath) Header(hash types.Hash) (*types.Header, error) {
 }
 
 // Add adds a new header to the graph.
-func (sp *simplePath) Add(header *types.Header) error {
+func (sp *simplePathfinder) Add(header *types.Header) error {
 	_, ok := sp.headers[header.Hash]
 	if ok {
 		return errors.New("header already in graph")
@@ -79,7 +79,7 @@ func (sp *simplePath) Add(header *types.Header) error {
 }
 
 // Longest returns the longest path of the graph.
-func (sp *simplePath) Longest() []types.Hash {
+func (sp *simplePathfinder) Longest() []types.Hash {
 
 	// create a topological sort of all headers starting at the root
 	var hash types.Hash

--- a/node/pathfinder_test.go
+++ b/node/pathfinder_test.go
@@ -25,15 +25,54 @@ import (
 	"github.com/alvalor/alvalor-go/types"
 )
 
-func TestNewSimpleHeader(t *testing.T) {
+func TestNewSimplePathfinder(t *testing.T) {
 	root := &types.Header{Hash: types.Hash{1}}
 	sp := newSimplePathfinder(root)
 	assert.NotNil(t, sp.headers, "header map not initialized")
 	assert.NotNil(t, sp.children, "children map not initialized")
+	assert.NotNil(t, sp.pending, "pending map not initialized")
 	assert.Equal(t, root.Hash, sp.root, "root hash not saved")
 	if assert.NotEmpty(t, sp.headers, "root header not saved") {
 		assert.Equal(t, root, sp.headers[root.Hash], "root header not at correct index")
 	}
+}
+
+func TestSimplPathfinderKnows(t *testing.T) {
+
+	hash1 := types.Hash{1}
+	hash2 := types.Hash{2}
+
+	sp := &simplePathfinder{
+		headers: make(map[types.Hash]*types.Header),
+	}
+	sp.headers[hash1] = &types.Header{}
+
+	ok := sp.Knows(hash1)
+	assert.True(t, ok, "hash one not known")
+
+	ok = sp.Knows(hash2)
+	assert.False(t, ok, "hash two known")
+}
+
+func TestSimplePathfinderHeader(t *testing.T) {
+
+	hash1 := types.Hash{1}
+	hash2 := types.Hash{2}
+
+	header1 := &types.Header{Hash: hash1}
+
+	sp := &simplePathfinder{
+		headers: make(map[types.Hash]*types.Header),
+	}
+	sp.headers[header1.Hash] = header1
+
+	result, err := sp.Header(hash1)
+	if assert.Nil(t, err, "could not retrieve first header") {
+		assert.Equal(t, header1, result, "retrieved header not equal")
+	}
+
+	_, err = sp.Header(hash2)
+	assert.NotNil(t, err, "could retrieve second header")
 }
 
 func TestSimplePathAddExistingHash(t *testing.T) {
@@ -41,14 +80,13 @@ func TestSimplePathAddExistingHash(t *testing.T) {
 	header := &types.Header{Hash: types.Hash{1}, Parent: types.Hash{0}}
 
 	sp := &simplePathfinder{
-		headers:  make(map[types.Hash]*types.Header),
-		children: make(map[types.Hash][]types.Hash),
+		headers: make(map[types.Hash]*types.Header),
 	}
 
 	sp.headers[header.Parent] = &types.Header{}
 	sp.headers[header.Hash] = &types.Header{}
-	err := sp.Add(header)
 
+	err := sp.Add(header)
 	assert.NotNil(t, err, "could insert duplicate header")
 }
 
@@ -57,13 +95,15 @@ func TestSimplePathAddMissingParent(t *testing.T) {
 	header := &types.Header{Hash: types.Hash{1}, Parent: types.Hash{0}}
 
 	sp := &simplePathfinder{
-		headers:  make(map[types.Hash]*types.Header),
-		children: make(map[types.Hash][]types.Hash),
+		headers: make(map[types.Hash]*types.Header),
+		pending: make(map[types.Hash][]*types.Header),
 	}
 
 	err := sp.Add(header)
-
-	assert.NotNil(t, err, "could insert with missing parent")
+	if assert.Nil(t, err, "could not insert with missing parent") {
+		assert.NotEmpty(t, sp.pending, "header missing from pending")
+		assert.Contains(t, sp.pending[header.Parent], header, "header not correctly listed in pending")
+	}
 }
 
 func TestSimplePathAddValidHeader(t *testing.T) {
@@ -74,6 +114,7 @@ func TestSimplePathAddValidHeader(t *testing.T) {
 	sp := &simplePathfinder{
 		headers:  make(map[types.Hash]*types.Header),
 		children: make(map[types.Hash][]types.Hash),
+		pending:  make(map[types.Hash][]*types.Header),
 	}
 
 	sp.headers[header1.Hash] = header1

--- a/node/pathfinder_test.go
+++ b/node/pathfinder_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/alvalor/alvalor-go/types"
 )
 
-func TestNewSimplePath(t *testing.T) {
+func TestNewSimpleHeader(t *testing.T) {
 	root := &types.Header{Hash: types.Hash{1}}
-	sp := newSimplePaths(root)
+	sp := newSimplePathfinder(root)
 	assert.NotNil(t, sp.headers, "header map not initialized")
 	assert.NotNil(t, sp.children, "children map not initialized")
 	assert.Equal(t, root.Hash, sp.root, "root hash not saved")
@@ -40,7 +40,7 @@ func TestSimplePathAddExistingHash(t *testing.T) {
 
 	header := &types.Header{Hash: types.Hash{1}, Parent: types.Hash{0}}
 
-	sp := &simplePath{
+	sp := &simplePathfinder{
 		headers:  make(map[types.Hash]*types.Header),
 		children: make(map[types.Hash][]types.Hash),
 	}
@@ -56,7 +56,7 @@ func TestSimplePathAddMissingParent(t *testing.T) {
 
 	header := &types.Header{Hash: types.Hash{1}, Parent: types.Hash{0}}
 
-	sp := &simplePath{
+	sp := &simplePathfinder{
 		headers:  make(map[types.Hash]*types.Header),
 		children: make(map[types.Hash][]types.Hash),
 	}
@@ -71,7 +71,7 @@ func TestSimplePathAddValidHeader(t *testing.T) {
 	header1 := &types.Header{Hash: types.Hash{1}, Parent: types.Hash{0}}
 	header2 := &types.Header{Hash: types.Hash{2}, Parent: types.Hash{1}}
 
-	sp := &simplePath{
+	sp := &simplePathfinder{
 		headers:  make(map[types.Hash]*types.Header),
 		children: make(map[types.Hash][]types.Hash),
 	}
@@ -94,7 +94,7 @@ func TestSimplePathLongestRootOnly(t *testing.T) {
 
 	header := &types.Header{Hash: types.Hash{1}, Parent: types.Hash{0}, Diff: 1}
 
-	sp := newSimplePaths(header)
+	sp := newSimplePathfinder(header)
 
 	path := sp.Longest()
 
@@ -108,7 +108,7 @@ func TestSimplePathLongestLinearOnly(t *testing.T) {
 	header3 := &types.Header{Hash: types.Hash{3}, Parent: types.Hash{2}, Diff: 1}
 	header4 := &types.Header{Hash: types.Hash{4}, Parent: types.Hash{3}, Diff: 1}
 
-	sp := newSimplePaths(header1)
+	sp := newSimplePathfinder(header1)
 	_ = sp.Add(header2)
 	_ = sp.Add(header3)
 	_ = sp.Add(header4)
@@ -126,7 +126,7 @@ func TestSimplePathLongestShortHeavy(t *testing.T) {
 	header4 := &types.Header{Hash: types.Hash{4}, Parent: types.Hash{3}, Diff: 1}
 	header5 := &types.Header{Hash: types.Hash{5}, Parent: types.Hash{1}, Diff: 10}
 
-	sp := newSimplePaths(header1)
+	sp := newSimplePathfinder(header1)
 	_ = sp.Add(header2)
 	_ = sp.Add(header3)
 	_ = sp.Add(header4)
@@ -146,7 +146,7 @@ func TestSimplePathLongestLongHeavy(t *testing.T) {
 	header4 := &types.Header{Hash: types.Hash{4}, Parent: types.Hash{3}, Diff: 5}
 	header5 := &types.Header{Hash: types.Hash{5}, Parent: types.Hash{1}, Diff: 10}
 
-	sp := newSimplePaths(header1)
+	sp := newSimplePathfinder(header1)
 	_ = sp.Add(header2)
 	_ = sp.Add(header3)
 	_ = sp.Add(header4)
@@ -175,7 +175,7 @@ func TestSimplePathLongestEqualHeavy(t *testing.T) {
 	header12 := &types.Header{Hash: types.Hash{12}, Parent: types.Hash{5}, Diff: 8}
 	header13 := &types.Header{Hash: types.Hash{13}, Parent: types.Hash{5}, Diff: 32}
 
-	sp := newSimplePaths(header1)
+	sp := newSimplePathfinder(header1)
 	_ = sp.Add(header2)
 	_ = sp.Add(header3)
 	_ = sp.Add(header4)

--- a/node/pathfinder_test.go
+++ b/node/pathfinder_test.go
@@ -96,7 +96,7 @@ func TestSimplePathLongestRootOnly(t *testing.T) {
 
 	sp := newSimplePathfinder(header)
 
-	path := sp.Longest()
+	path, _ := sp.Longest()
 
 	assert.Equal(t, path, []types.Hash{header.Hash})
 }
@@ -113,7 +113,7 @@ func TestSimplePathLongestLinearOnly(t *testing.T) {
 	_ = sp.Add(header3)
 	_ = sp.Add(header4)
 
-	path := sp.Longest()
+	path, _ := sp.Longest()
 
 	assert.Equal(t, path, []types.Hash{header4.Hash, header3.Hash, header2.Hash, header1.Hash})
 }
@@ -132,7 +132,7 @@ func TestSimplePathLongestShortHeavy(t *testing.T) {
 	_ = sp.Add(header4)
 	_ = sp.Add(header5)
 
-	path := sp.Longest()
+	path, _ := sp.Longest()
 
 	assert.Equal(t, path, []types.Hash{header5.Hash, header1.Hash})
 
@@ -152,7 +152,7 @@ func TestSimplePathLongestLongHeavy(t *testing.T) {
 	_ = sp.Add(header4)
 	_ = sp.Add(header5)
 
-	path := sp.Longest()
+	path, _ := sp.Longest()
 
 	assert.Equal(t, path, []types.Hash{header4.Hash, header3.Hash, header2.Hash, header1.Hash})
 }
@@ -189,7 +189,7 @@ func TestSimplePathLongestEqualHeavy(t *testing.T) {
 	_ = sp.Add(header12)
 	_ = sp.Add(header13)
 
-	path := sp.Longest()
+	path, _ := sp.Longest()
 
 	assert.Equal(t, path, []types.Hash{header13.Hash, header5.Hash, header1.Hash})
 }

--- a/node/statePool.go
+++ b/node/statePool.go
@@ -68,15 +68,14 @@ func (p *simplePool) Add(tx *types.Transaction) error {
 		return errors.Wrap(err, "could not encode transaction")
 	}
 
-	hash := tx.Hash()
 	data := buf.Bytes()
-	err = p.store.Put(hash[:], data)
+	err = p.store.Put(tx.Hash[:], data)
 	if err != nil {
 		return errors.Wrap(err, "could not put data")
 	}
 
 	// TODO: fix tests to check ids entry
-	p.hashes[hash] = struct{}{}
+	p.hashes[tx.Hash] = struct{}{}
 
 	return nil
 }

--- a/node/statePool_test.go
+++ b/node/statePool_test.go
@@ -47,9 +47,9 @@ func TestPoolAdd(t *testing.T) {
 	codec.On("Encode", mock.Anything, tx3).Return(nil)
 
 	store := &StoreMock{}
-	store.On("Put", tx1.Hash(), mock.Anything).Return(nil)
-	store.On("Put", tx2.Hash(), mock.Anything).Return(nil)
-	store.On("Put", tx3.Hash(), mock.Anything).Return(errors.New("could not put"))
+	store.On("Put", tx1.Hash, mock.Anything).Return(nil)
+	store.On("Put", tx2.Hash, mock.Anything).Return(nil)
+	store.On("Put", tx3.Hash, mock.Anything).Return(errors.New("could not put"))
 
 	pool := simplePool{
 		codec:  codec,
@@ -69,9 +69,9 @@ func TestPoolAdd(t *testing.T) {
 
 func TestPoolGet(t *testing.T) {
 
-	id1 := [32]byte{1, 2, 3, 4}
-	id2 := [32]byte{4, 5, 6, 7}
-	id3 := [32]byte{8, 9, 0, 1}
+	id1 := types.Hash{1, 2, 3, 4}
+	id2 := types.Hash{4, 5, 6, 7}
+	id3 := types.Hash{8, 9, 0, 1}
 
 	tx1 := &types.Transaction{Data: id1[:]}
 	tx3 := &types.Transaction{Data: id3[:]}
@@ -102,8 +102,8 @@ func TestPoolGet(t *testing.T) {
 
 func TestPoolRemove(t *testing.T) {
 
-	id1 := [32]byte{1, 2, 3, 4}
-	id2 := [32]byte{4, 5, 6, 7}
+	id1 := types.Hash{1, 2, 3, 4}
+	id2 := types.Hash{4, 5, 6, 7}
 
 	store := &StoreMock{}
 	store.On("Del", id1).Return(nil)
@@ -123,8 +123,8 @@ func TestPoolRemove(t *testing.T) {
 
 func TestPoolKnown(t *testing.T) {
 
-	id1 := [32]byte{1, 2, 3, 4}
-	id2 := [32]byte{5, 6, 7, 8}
+	id1 := types.Hash{1, 2, 3, 4}
+	id2 := types.Hash{5, 6, 7, 8}
 
 	pool := simplePool{
 		hashes: make(map[types.Hash]struct{}),

--- a/node/statePool_test.go
+++ b/node/statePool_test.go
@@ -41,15 +41,19 @@ func TestPoolAdd(t *testing.T) {
 	tx2 := &types.Transaction{Data: []byte{4, 5, 6, 7}}
 	tx3 := &types.Transaction{Data: []byte{8, 9, 0, 1}}
 
+	tx1.Hash = tx1.GetHash()
+	tx2.Hash = tx2.GetHash()
+	tx3.Hash = tx3.GetHash()
+
 	codec := &CodecMock{}
 	codec.On("Encode", mock.Anything, tx1).Return(nil)
 	codec.On("Encode", mock.Anything, tx2).Return(errors.New("could not encode"))
 	codec.On("Encode", mock.Anything, tx3).Return(nil)
 
 	store := &StoreMock{}
-	store.On("Put", tx1.Hash, mock.Anything).Return(nil)
-	store.On("Put", tx2.Hash, mock.Anything).Return(nil)
-	store.On("Put", tx3.Hash, mock.Anything).Return(errors.New("could not put"))
+	store.On("Put", tx1.Hash[:], mock.Anything).Return(nil)
+	store.On("Put", tx2.Hash[:], mock.Anything).Return(nil)
+	store.On("Put", tx3.Hash[:], mock.Anything).Return(errors.New("could not put"))
 
 	pool := simplePool{
 		codec:  codec,
@@ -76,10 +80,13 @@ func TestPoolGet(t *testing.T) {
 	tx1 := &types.Transaction{Data: id1[:]}
 	tx3 := &types.Transaction{Data: id3[:]}
 
+	tx1.Hash = tx1.GetHash()
+	tx3.Hash = tx3.GetHash()
+
 	store := &StoreMock{}
-	store.On("Get", id1).Return(id1, nil)
-	store.On("Get", id2).Return(id2, errors.New("could not get"))
-	store.On("Get", id3).Return(id3, nil)
+	store.On("Get", id1[:]).Return(id1[:], nil)
+	store.On("Get", id2[:]).Return(id2[:], errors.New("could not get"))
+	store.On("Get", id3[:]).Return(id3[:], nil)
 
 	// this is not ideal, but the way returns are evaluated immediately, we can't
 	// use the closure of the Run function to switch on the buffer contents
@@ -106,8 +113,8 @@ func TestPoolRemove(t *testing.T) {
 	id2 := types.Hash{4, 5, 6, 7}
 
 	store := &StoreMock{}
-	store.On("Del", id1).Return(nil)
-	store.On("Del", id2).Return(errors.New("could not del"))
+	store.On("Del", id1[:]).Return(nil)
+	store.On("Del", id2[:]).Return(errors.New("could not del"))
 
 	pool := simplePool{
 		store:  store,

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -25,24 +25,17 @@ import (
 
 // Transaction represents an atomic standard transaction on the Alvalor network.
 type Transaction struct {
+	Hash       Hash
 	Transfers  []*Transfer
 	Fees       []*Fee
 	Data       []byte
 	Nonce      uint64
 	Signatures [][]byte
-	hash       Hash
 }
 
-// Hash returns the unique hash of the transaction.
-func (tx *Transaction) Hash() Hash {
-	if tx.hash == ZeroHash {
-		hash := tx.calc()
-		copy(tx.hash[:], hash)
-	}
-	return tx.hash
-}
-
-func (tx Transaction) calc() []byte {
+// GetHash returns the unique hash of the transaction.
+func (tx *Transaction) GetHash() Hash {
+	var hash Hash
 	buf := make([]byte, 8)
 	h, _ := blake2s.New256(nil)
 	for _, transfer := range tx.Transfers {
@@ -59,5 +52,7 @@ func (tx Transaction) calc() []byte {
 	_, _ = h.Write(tx.Data)
 	binary.LittleEndian.PutUint64(buf, tx.Nonce)
 	_, _ = h.Write(buf)
-	return h.Sum(nil)
+	tmp := h.Sum(nil)
+	copy(hash[:], tmp)
+	return hash
 }


### PR DESCRIPTION
This PR adjusts the synchronization exchange between peers with the help of the new pathfinder which manages all headers. It currently does not persist anything on disk. Beyond the header download, what is missing is starting and aborting block downloads depending on how our longest path evolves/changes.