### PR TITLE
Improve synchronization handshake

### DIFF
--- a/node/handleEvent.go
+++ b/node/handleEvent.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/alvalor/alvalor-go/network"
+	"github.com/alvalor/alvalor-go/types"
 )
 
 func handleEvent(log zerolog.Logger, wg *sync.WaitGroup, net Network, finder pathfinder, peers peerManager, handlers Handlers, event interface{}) {
@@ -39,12 +40,29 @@ func handleEvent(log zerolog.Logger, wg *sync.WaitGroup, net Network, finder pat
 
 		peers.Active(e.Address)
 
+		// get list of hashes from our best path and the current distance
 		path, distance := finder.Longest()
-		status := &Status{
-			Distance: distance,
-			Hash:     path[0],
+
+		// collect headers from the top of our longest path backwards
+		// use increasing distance after first 8, finish with root (genesis)
+		var locators []types.Hash
+		index := 0
+		step := 1
+		for index < len(path)-1 {
+			locators = append(locators, path[index])
+			if len(locators) >= 8 {
+				step *= 2
+			}
+			index += step
 		}
-		err := net.Send(e.Address, status)
+		locators = append(locators, path[len(path)-1])
+
+		// send our current distance and locator hashes
+		sync := &Sync{
+			Distance: distance,
+			Locators: locators,
+		}
+		err := net.Send(e.Address, sync)
 		if err != nil {
 			log.Error().Err(err).Msg("could not send status message")
 			return

--- a/node/handleMessage.go
+++ b/node/handleMessage.go
@@ -222,15 +222,9 @@ func handleMessage(log zerolog.Logger, wg *sync.WaitGroup, net Network, chain Bl
 		log = log.With().Int("num_req", len(req)).Logger()
 
 		// request the missing transactions from the peer
-		// TODO: better to add into a pending queue
-		request := &Request{Hashes: req}
-		err := net.Send(address, request)
-		if err != nil {
-			log.Error().Err(err).Msg("could not request transactions")
-			return
-		}
+		handlers.RequestTransactions(req, address)
 
-		log.Debug().Msg("processed inventory message")
+		log.Debug().Msg("processed inventory message, enqued request")
 
 	case *Request:
 

--- a/node/handleTransactionRequests.go
+++ b/node/handleTransactionRequests.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"sync"
+	"time"
+
+	"github.com/alvalor/alvalor-go/types"
+	"github.com/rs/zerolog"
+)
+
+func handleTransactionRequests(log zerolog.Logger, wg *sync.WaitGroup, net Network, requests map[types.Hash][]string, stop <-chan struct{}) {
+	defer wg.Done()
+
+	log = log.With().Str("component", "transaction requests").Logger()
+
+	ticker := time.NewTicker(time.Millisecond * 100)
+	for {
+		select {
+		case <-stop:
+			ticker.Stop()
+			return
+		case <-ticker.C:
+		}
+
+		outgoingRequests := transformToOutgoingRequests(requests)
+
+		for addr, hashes := range outgoingRequests {
+			request := &Request{Hashes: hashes}
+			err := net.Send(addr, request)
+			if err != nil {
+				log.Error().Err(err).Msg("could not request transactions")
+				return
+			}
+		}
+	}
+}
+
+// tranforms map of [tx hashes -> peers addr which have it] to the map of [peer addr -> tx hashes to request]
+func transformToOutgoingRequests(requests map[types.Hash][]string) map[string][]types.Hash {
+	result := make(map[string][]types.Hash)
+
+	//map where key is an address and value is amount of planned hashes to send
+	outgoingTxReqCountMap := make(map[string]int)
+	for hash, addresses := range requests {
+		//find address which has least amount of tx hashes to request
+		minAddr := ""
+		minAddrCount := 0
+		for _, addr := range addresses {
+			if count, ok := outgoingTxReqCountMap[addr]; ok {
+				if minAddr == "" || count < minAddrCount {
+					minAddr = addr
+					minAddrCount = count
+				}
+				continue
+			}
+			//Found zero planned requests for this peer, therefore just selecting it
+			minAddr = addr
+			break
+		}
+
+		outgoingTxReqCountMap[minAddr] = minAddrCount + 1
+
+		if outgoing, ok := result[minAddr]; ok {
+			result[minAddr] = append(outgoing, hash)
+		} else {
+			result[minAddr] = []types.Hash{hash}
+		}
+
+	}
+	return result
+}

--- a/node/handleTransactionRequests.go
+++ b/node/handleTransactionRequests.go
@@ -40,9 +40,9 @@ func handleTransactionRequests(log zerolog.Logger, wg *sync.WaitGroup, net Netwo
 		}
 
 		requestMessages := getRequestMessages(requestsStream)
-		outgoingRequests := transformToOutgoingRequests(requestMessages)
+		requestsQueue := newTransactionRequestsQueue(requestMessages)
 
-		for addr, hashes := range outgoingRequests {
+		for addr, hashes := range requestsQueue.getData() {
 			request := &Request{Hashes: hashes}
 			err := net.Send(addr, request)
 			if err != nil {
@@ -86,39 +86,4 @@ Loop:
 		}
 	}
 	return requestMessages
-}
-
-// tranforms map of [tx hashes -> peers addr which have it] to the map of [peer addr -> tx hashes to request]
-func transformToOutgoingRequests(requests map[types.Hash][]string) map[string][]types.Hash {
-	result := make(map[string][]types.Hash)
-
-	//map where key is an address and value is amount of planned hashes to send
-	outgoingTxReqCountMap := make(map[string]int)
-	for hash, addresses := range requests {
-		//find address which has least amount of tx hashes to request
-		minAddr := ""
-		minAddrCount := 0
-		for _, addr := range addresses {
-			if count, ok := outgoingTxReqCountMap[addr]; ok {
-				if minAddr == "" || count < minAddrCount {
-					minAddr = addr
-					minAddrCount = count
-				}
-				continue
-			}
-			//Found zero planned requests for this peer, therefore just selecting it
-			minAddr = addr
-			break
-		}
-
-		outgoingTxReqCountMap[minAddr] = minAddrCount + 1
-
-		if outgoing, ok := result[minAddr]; ok {
-			result[minAddr] = append(outgoing, hash)
-		} else {
-			result[minAddr] = []types.Hash{hash}
-		}
-
-	}
-	return result
 }

--- a/node/handlers.go
+++ b/node/handlers.go
@@ -30,4 +30,5 @@ type Handlers interface {
 	Message(address string, message interface{})
 	Entity(entity Entity)
 	Collect(path []types.Hash)
+	RequestTransactions(hashes []types.Hash, addr string)
 }

--- a/node/messages.go
+++ b/node/messages.go
@@ -23,15 +23,15 @@ import (
 	"github.com/alvalor/alvalor-go/types"
 )
 
-// Status message shares our top block height.
-type Status struct {
+// Sync message shares our current best distance and locator hashes for our best path.
+type Sync struct {
 	Distance uint64
-	Hash     types.Hash
+	Locators []types.Hash
 }
 
-// Sync requests headers we are missing.
-type Sync struct {
-	Locators []types.Hash
+// Path message shares the partial path from a header hash to our best header.
+type Path struct {
+	Hashes []types.Hash
 }
 
 // Mempool is a message containing details about the memory pool.

--- a/node/messages.go
+++ b/node/messages.go
@@ -53,3 +53,8 @@ type Request struct {
 type Batch struct {
 	Transactions []*types.Transaction
 }
+
+type internalTransactionRequest struct {
+	hashes []types.Hash
+	addr   string
+}

--- a/node/mocks_test.go
+++ b/node/mocks_test.go
@@ -162,6 +162,10 @@ func (h *HandlersMock) Collect(path []types.Hash) {
 	h.Called(path)
 }
 
+func (h *HandlersMock) RequestTransactions(hashes []types.Hash, address string) {
+	h.Called(hashes, address)
+}
+
 type NetworkMock struct {
 	mock.Mock
 }

--- a/node/node.go
+++ b/node/node.go
@@ -46,20 +46,6 @@ type Codec interface {
 }
 
 type simpleNode struct {
-<<<<<<< HEAD
-	log                   zerolog.Logger
-	wg                    *sync.WaitGroup
-	net                   Network
-	chain                 Blockchain
-	finder                pathfinder
-	peers                 peerManager
-	pool                  poolManager
-	events                eventManager
-	stream                chan interface{}
-	subscribers           []subscriber
-	requestedTransactions map[types.Hash][]string
-	stop                  chan struct{}
-=======
 	log                       zerolog.Logger
 	wg                        *sync.WaitGroup
 	net                       Network
@@ -70,9 +56,9 @@ type simpleNode struct {
 	events                    eventManager
 	stream                    chan interface{}
 	subscribers               []subscriber
-	transactionRequestsStream chan interface{}
+	requestedTransactions     map[types.Hash][]string
 	stop                      chan struct{}
->>>>>>> Updated handling of transation requests to use channel instead of shared dictionary.
+	transactionRequestsStream chan interface{}
 }
 
 type subscriber struct {

--- a/node/node.go
+++ b/node/node.go
@@ -46,16 +46,18 @@ type Codec interface {
 }
 
 type simpleNode struct {
-	log         zerolog.Logger
-	wg          *sync.WaitGroup
-	net         Network
-	chain       Blockchain
-	finder      pathfinder
-	peers       peerManager
-	pool        poolManager
-	events      eventManager
-	stream      chan interface{}
-	subscribers []subscriber
+	log                   zerolog.Logger
+	wg                    *sync.WaitGroup
+	net                   Network
+	chain                 Blockchain
+	finder                pathfinder
+	peers                 peerManager
+	pool                  poolManager
+	events                eventManager
+	stream                chan interface{}
+	subscribers           []subscriber
+	requestedTransactions map[types.Hash][]string
+	stop                  chan struct{}
 }
 
 type subscriber struct {
@@ -98,11 +100,20 @@ func New(log zerolog.Logger, net Network, chain Blockchain, codec Codec, input <
 	// create the subscriber channel
 	n.stream = make(chan interface{}, 128)
 
+	// create requested transactions dictionary to send this message evenly
+	n.requestedTransactions = make(map[types.Hash][]string)
+
+	// create the channel for shutdown
+	n.stop = make(chan struct{})
+
 	// handle all input messages we get
 	n.Input(input)
 	n.events = &simpleEventManager{stream: n.stream}
 
 	n.Stream()
+
+	// send transaction requests
+	n.TransactionRequests()
 
 	return n
 }
@@ -156,8 +167,25 @@ func (n *simpleNode) Subscriber(sub subscriber) {
 	go handleSubscriber(n.log, n.wg, sub)
 }
 
+func (n *simpleNode) RequestTransactions(hashes []types.Hash, addr string) {
+	for _, hash := range hashes {
+		if hashAddr, ok := n.requestedTransactions[hash]; ok {
+			n.requestedTransactions[hash] = append(hashAddr, addr)
+			continue
+		}
+
+		n.requestedTransactions[hash] = []string{addr}
+	}
+}
+
+func (n *simpleNode) TransactionRequests() {
+	n.wg.Add(1)
+	go handleTransactionRequests(n.log, n.wg, n.net, n.requestedTransactions, n.stop)
+}
+
 func (n *simpleNode) Stop() {
 	n.wg.Wait()
+	close(n.stop)
 	close(n.stream)
 	for _, sub := range n.subscribers {
 		close(sub.channel)

--- a/node/transactionRequestsQueue.go
+++ b/node/transactionRequestsQueue.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 The Alvalor Authors
+//
+// This file is part of Alvalor.
+//
+// Alvalor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alvalor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Alvalor.  If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"github.com/alvalor/alvalor-go/types"
+)
+
+type transactionRequestsQueue interface {
+	getData() map[string][]types.Hash
+}
+
+type simpleTransactionRequestsQueue struct {
+	requests map[types.Hash][]string
+}
+
+func newTransactionRequestsQueue(requests map[types.Hash][]string) simpleTransactionRequestsQueue {
+	return simpleTransactionRequestsQueue{requests: requests}
+}
+
+func (q *simpleTransactionRequestsQueue) getData() map[string][]types.Hash {
+	data := q.transformToOutgoingRequests()
+	return data
+}
+
+// tranforms map of [tx hashes -> peers addr which have it] to the map of [peer addr -> tx hashes to request]
+func (q *simpleTransactionRequestsQueue) transformToOutgoingRequests() map[string][]types.Hash {
+	result := make(map[string][]types.Hash)
+
+	//map where key is an address and value is amount of planned hashes to send
+	outgoingTxReqCountMap := make(map[string]int)
+	for hash, addresses := range q.requests {
+		//find address which has least amount of tx hashes to request
+		minAddr := ""
+		minAddrCount := 0
+		for _, addr := range addresses {
+			if count, ok := outgoingTxReqCountMap[addr]; ok {
+				if minAddr == "" || count < minAddrCount {
+					minAddr = addr
+					minAddrCount = count
+				}
+				continue
+			}
+			//Found zero planned requests for this peer, therefore just selecting it
+			minAddr = addr
+			break
+		}
+
+		outgoingTxReqCountMap[minAddr] = minAddrCount + 1
+
+		if outgoing, ok := result[minAddr]; ok {
+			result[minAddr] = append(outgoing, hash)
+		} else {
+			result[minAddr] = []types.Hash{hash}
+		}
+
+	}
+	return result
+}


### PR DESCRIPTION
This PR replaces the "status-sync" message pair with a changed sync message. Rather than sending our current best distance with the current best header hash, we send the current best distance with our whole set of locator hashes. This initial increased overhead in terms of message size cuts down on the need for one roundtrip. It also opens the door to sending just the header hashes of missing headers, rather than the full headers, allowing the other peer to pick where to download the full headers and giving him the ability to parallelize the downloads.